### PR TITLE
Clustering small detected pockets

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,6 +11,7 @@ public
 
 __pycache__
 .vscode
+build
 
 # Coverage
 .coverage

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 <h1 align="center">POVME</h1>
 
-<h4 align="center">Detect and characterize pockets from molecular simulations.</h4>
+<h4 align="center">Detect and characterize protein pockets.</h4>
 
 <p align="center">
     <a href="https://github.com/durrantlab/POVME/actions/workflows/tests.yml">
@@ -17,8 +17,8 @@
     </a>
 </p>
 
-POVME (POcket Volume MEasurer) is an open-source tool designed for detailed analysis of ligand-binding pocket shapes and volumes in proteins.
-Initially developed to support structure-guided drug discovery, POVME has been widely adopted for its simplicity, speed, and flexibility.
+POVME (**PO**cket **V**olume **ME**asurer) is an open-source tool designed for detailed analysis of ligand-binding pocket shapes and volumes in proteins.
+Initially developed to support structure-based drug discovery, POVME has been widely adopted for its simplicity, speed, and flexibility.
 
 ## Why binding pocket analysis?
 
@@ -42,7 +42,7 @@ pixi install
 Now you can activate the new virtual environment using
 
 ```sh
-pixi shell
+pixi shell -e dev
 ```
 
 ## Installation
@@ -95,8 +95,8 @@ This will install the specified version of `povme` and its dependencies into you
 
 If you use POVME in your work, please cite:
 
-1.  Durrant, J.D., L. Votapka, J. Sørensen, and R. E. Amaro (2014). "POVME 2.0: An Enhanced Tool for Determining Pocket Shape and Volume Characteristics." J. Chem. Theory Comput. 10(11):5047-5056.
-2.  Durrant, J. D., C. A. de Oliveira, et al. (2011). "POVME: An algorithm for measuring binding-pocket volumes." J Mol Graph Model 29(5): 773-776.
+1.  Durrant, J. D., Votapka, L., Sørensen, J., & Amaro, R. E. (2014). POVME 2.0: An Enhanced Tool for Determining Pocket Shape and Volume Characteristics. *J. Chem. Theory Comput. 10*(11), 5047-5056.
+2.  Durrant, J. D., de Oliveira, C. A. F., & McCammon, J. A. (2011). POVME: An algorithm for measuring binding-pocket volumes. *J. Mol. Graph. Model. 29*(5), 773-776.
 
 ## License
 

--- a/pixi.lock
+++ b/pixi.lock
@@ -1,4 +1,4 @@
-version: 5
+version: 6
 environments:
   default:
     channels:
@@ -60,7 +60,7 @@ environments:
       - pypi: https://files.pythonhosted.org/packages/f1/54/65af8de681fa8255402c80eda2a501ba467921d5a7a028c9c22a2c2eedb5/msgpack-1.1.0-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.whl
       - pypi: https://files.pythonhosted.org/packages/88/ef/eb23f262cca3c0c4eb7ab1933c3b1f03d021f2c48f54763065b6f0e321be/packaging-24.2-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/04/52/c97c58a33b3d6c89a8138788576d372a90a6556f354799971c6b4d16d871/protobuf-5.29.1-cp38-abi3-manylinux2014_x86_64.whl
-      - pypi: git+https://github.com/durrantlab/pymolecule.git@121c34103169d362f4ed2ca9207dd5555f9dc25b
+      - pypi: git+https://github.com/durrantlab/pymolecule.git?rev=423cf64f17c21881a1685402437bd69a81e79ccf#423cf64f17c21881a1685402437bd69a81e79ccf
       - pypi: https://files.pythonhosted.org/packages/82/ad/2eaf308c64e39704629863720c59b82e1ceed814fca319b8585deb92bb74/ray-2.40.0-cp312-cp312-manylinux2014_x86_64.whl
       - pypi: https://files.pythonhosted.org/packages/b7/59/2056f61236782a2c86b33906c025d4f4a0b17be0161b63b70fd9e8775d36/referencing-0.35.1-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/f9/9b/335f9764261e915ed497fcdeb11df5dfd6f7bf257d4a6a2a686d80da4d54/requests-2.32.3-py3-none-any.whl
@@ -208,7 +208,7 @@ environments:
       - pypi: https://files.pythonhosted.org/packages/d1/0f/8910b19ac0670a0f80ce1008e5e751c4a57e14d2c4c13a482aa6079fa9d6/jsonschema_specifications-2024.10.1-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/f1/54/65af8de681fa8255402c80eda2a501ba467921d5a7a028c9c22a2c2eedb5/msgpack-1.1.0-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.whl
       - pypi: https://files.pythonhosted.org/packages/04/52/c97c58a33b3d6c89a8138788576d372a90a6556f354799971c6b4d16d871/protobuf-5.29.1-cp38-abi3-manylinux2014_x86_64.whl
-      - pypi: git+https://github.com/durrantlab/pymolecule.git@121c34103169d362f4ed2ca9207dd5555f9dc25b
+      - pypi: git+https://github.com/durrantlab/pymolecule.git?rev=423cf64f17c21881a1685402437bd69a81e79ccf#423cf64f17c21881a1685402437bd69a81e79ccf
       - pypi: https://files.pythonhosted.org/packages/bd/24/12818598c362d7f300f18e74db45963dbcb85150324092410c8b49405e42/pyproject_hooks-1.2.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/82/ad/2eaf308c64e39704629863720c59b82e1ceed814fca319b8585deb92bb74/ray-2.40.0-cp312-cp312-manylinux2014_x86_64.whl
       - pypi: https://files.pythonhosted.org/packages/b7/59/2056f61236782a2c86b33906c025d4f4a0b17be0161b63b70fd9e8775d36/referencing-0.35.1-py3-none-any.whl
@@ -390,30 +390,20 @@ environments:
       - pypi: https://files.pythonhosted.org/packages/f1/54/65af8de681fa8255402c80eda2a501ba467921d5a7a028c9c22a2c2eedb5/msgpack-1.1.0-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.whl
       - pypi: https://files.pythonhosted.org/packages/ef/82/7a9d0550484a62c6da82858ee9419f3dd1ccc9aa1c26a1e43da3ecd20b0d/natsort-8.4.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/04/52/c97c58a33b3d6c89a8138788576d372a90a6556f354799971c6b4d16d871/protobuf-5.29.1-cp38-abi3-manylinux2014_x86_64.whl
-      - pypi: git+https://github.com/durrantlab/pymolecule.git@121c34103169d362f4ed2ca9207dd5555f9dc25b
+      - pypi: git+https://github.com/durrantlab/pymolecule.git?rev=423cf64f17c21881a1685402437bd69a81e79ccf#423cf64f17c21881a1685402437bd69a81e79ccf
       - pypi: https://files.pythonhosted.org/packages/82/ad/2eaf308c64e39704629863720c59b82e1ceed814fca319b8585deb92bb74/ray-2.40.0-cp312-cp312-manylinux2014_x86_64.whl
       - pypi: https://files.pythonhosted.org/packages/ab/df/4ee467ab39cc1de4b852c212c1ed3becfec2e486a51ac1ce0091f85f38d7/wcmatch-10.0-py3-none-any.whl
       - pypi: .
 packages:
-- kind: conda
-  name: _libgcc_mutex
-  version: '0.1'
-  build: conda_forge
-  subdir: linux-64
-  url: https://conda.anaconda.org/conda-forge/linux-64/_libgcc_mutex-0.1-conda_forge.tar.bz2
+- conda: https://conda.anaconda.org/conda-forge/linux-64/_libgcc_mutex-0.1-conda_forge.tar.bz2
   sha256: fe51de6107f9edc7aa4f786a70f4a883943bc9d39b3bb7307c04c41410990726
   md5: d7c89558ba9fa0495403155b64376d81
   license: None
   purls: []
   size: 2562
   timestamp: 1578324546067
-- kind: conda
-  name: _openmp_mutex
-  version: '4.5'
-  build: 2_gnu
+- conda: https://conda.anaconda.org/conda-forge/linux-64/_openmp_mutex-4.5-2_gnu.tar.bz2
   build_number: 16
-  subdir: linux-64
-  url: https://conda.anaconda.org/conda-forge/linux-64/_openmp_mutex-4.5-2_gnu.tar.bz2
   sha256: fbe2c5e56a653bebb982eda4876a9178aedfc2b545f25d0ce9c4c0b508253d22
   md5: 73aaf86a425cc6e73fcf236a5a46396d
   depends:
@@ -426,22 +416,14 @@ packages:
   purls: []
   size: 23621
   timestamp: 1650670423406
-- kind: pypi
+- pypi: https://files.pythonhosted.org/packages/ec/6a/bc7e17a3e87a2985d3e8f4da4cd0f481060eb78fb08596c42be62c90a4d9/aiosignal-1.3.2-py2.py3-none-any.whl
   name: aiosignal
   version: 1.3.2
-  url: https://files.pythonhosted.org/packages/ec/6a/bc7e17a3e87a2985d3e8f4da4cd0f481060eb78fb08596c42be62c90a4d9/aiosignal-1.3.2-py2.py3-none-any.whl
   sha256: 45cde58e409a301715980c2b01d0c28bdde3770d8290b5eb2173759d9acb31a5
   requires_dist:
   - frozenlist>=1.1.0
   requires_python: '>=3.9'
-- kind: conda
-  name: annotated-types
-  version: 0.7.0
-  build: pyhd8ed1ab_1
-  build_number: 1
-  subdir: noarch
-  noarch: python
-  url: https://conda.anaconda.org/conda-forge/noarch/annotated-types-0.7.0-pyhd8ed1ab_1.conda
+- conda: https://conda.anaconda.org/conda-forge/noarch/annotated-types-0.7.0-pyhd8ed1ab_1.conda
   sha256: e0ea1ba78fbb64f17062601edda82097fcf815012cf52bb704150a2668110d48
   md5: 2934f256a8acfe48f6ebb4fce6cde29c
   depends:
@@ -453,14 +435,7 @@ packages:
   - pkg:pypi/annotated-types?source=hash-mapping
   size: 18074
   timestamp: 1733247158254
-- kind: conda
-  name: asttokens
-  version: 3.0.0
-  build: pyhd8ed1ab_1
-  build_number: 1
-  subdir: noarch
-  noarch: python
-  url: https://conda.anaconda.org/conda-forge/noarch/asttokens-3.0.0-pyhd8ed1ab_1.conda
+- conda: https://conda.anaconda.org/conda-forge/noarch/asttokens-3.0.0-pyhd8ed1ab_1.conda
   sha256: 93b14414b3b3ed91e286e1cbe4e7a60c4e1b1c730b0814d1e452a8ac4b9af593
   md5: 8f587de4bcf981e26228f268df374a9b
   depends:
@@ -473,10 +448,9 @@ packages:
   - pkg:pypi/asttokens?source=hash-mapping
   size: 28206
   timestamp: 1733250564754
-- kind: pypi
+- pypi: https://files.pythonhosted.org/packages/6a/21/5b6702a7f963e95456c0de2d495f67bf5fd62840ac655dc451586d23d39a/attrs-24.2.0-py3-none-any.whl
   name: attrs
   version: 24.2.0
-  url: https://files.pythonhosted.org/packages/6a/21/5b6702a7f963e95456c0de2d495f67bf5fd62840ac655dc451586d23d39a/attrs-24.2.0-py3-none-any.whl
   sha256: 81921eb96de3191c8258c199618104dd27ac608d9366f5e35d011eae1867ede2
   requires_dist:
   - importlib-metadata ; python_full_version < '3.8'
@@ -521,14 +495,7 @@ packages:
   - mypy>=1.11.1 ; python_full_version >= '3.9' and platform_python_implementation == 'CPython' and extra == 'tests-mypy'
   - pytest-mypy-plugins ; python_full_version >= '3.9' and python_full_version < '3.13' and platform_python_implementation == 'CPython' and extra == 'tests-mypy'
   requires_python: '>=3.7'
-- kind: conda
-  name: attrs
-  version: 24.2.0
-  build: pyh71513ae_1
-  build_number: 1
-  subdir: noarch
-  noarch: python
-  url: https://conda.anaconda.org/conda-forge/noarch/attrs-24.2.0-pyh71513ae_1.conda
+- conda: https://conda.anaconda.org/conda-forge/noarch/attrs-24.2.0-pyh71513ae_1.conda
   sha256: 8488a116dffe204015a90b41982c0270534bd1070f44a00b316d59e4a79ae8c7
   md5: 2018839db45c79654b57a924fcdd27d0
   depends:
@@ -539,14 +506,7 @@ packages:
   - pkg:pypi/attrs?source=hash-mapping
   size: 56336
   timestamp: 1733520064905
-- kind: conda
-  name: babel
-  version: 2.16.0
-  build: pyhd8ed1ab_1
-  build_number: 1
-  subdir: noarch
-  noarch: python
-  url: https://conda.anaconda.org/conda-forge/noarch/babel-2.16.0-pyhd8ed1ab_1.conda
+- conda: https://conda.anaconda.org/conda-forge/noarch/babel-2.16.0-pyhd8ed1ab_1.conda
   sha256: f6205d3a62e87447e06e98d911559be0208d824976d77ab092796c9176611fcb
   md5: 3e23f7db93ec14c80525257d8affac28
   depends:
@@ -558,14 +518,7 @@ packages:
   - pkg:pypi/babel?source=hash-mapping
   size: 6551057
   timestamp: 1733236466015
-- kind: conda
-  name: backports
-  version: '1.0'
-  build: pyhd8ed1ab_5
-  build_number: 5
-  subdir: noarch
-  noarch: python
-  url: https://conda.anaconda.org/conda-forge/noarch/backports-1.0-pyhd8ed1ab_5.conda
+- conda: https://conda.anaconda.org/conda-forge/noarch/backports-1.0-pyhd8ed1ab_5.conda
   sha256: e1c3dc8b5aa6e12145423fed262b4754d70fec601339896b9ccf483178f690a6
   md5: 767d508c1a67e02ae8f50e44cacfadb2
   depends:
@@ -575,14 +528,7 @@ packages:
   purls: []
   size: 7069
   timestamp: 1733218168786
-- kind: conda
-  name: backports.tarfile
-  version: 1.2.0
-  build: pyhd8ed1ab_1
-  build_number: 1
-  subdir: noarch
-  noarch: python
-  url: https://conda.anaconda.org/conda-forge/noarch/backports.tarfile-1.2.0-pyhd8ed1ab_1.conda
+- conda: https://conda.anaconda.org/conda-forge/noarch/backports.tarfile-1.2.0-pyhd8ed1ab_1.conda
   sha256: a0f41db6d7580cec3c850e5d1b82cb03197dd49a3179b1cee59c62cd2c761b36
   md5: df837d654933488220b454c6a3b0fad6
   depends:
@@ -594,14 +540,7 @@ packages:
   - pkg:pypi/backports-tarfile?source=hash-mapping
   size: 32786
   timestamp: 1733325872620
-- kind: conda
-  name: beautifulsoup4
-  version: 4.12.3
-  build: pyha770c72_1
-  build_number: 1
-  subdir: noarch
-  noarch: python
-  url: https://conda.anaconda.org/conda-forge/noarch/beautifulsoup4-4.12.3-pyha770c72_1.conda
+- conda: https://conda.anaconda.org/conda-forge/noarch/beautifulsoup4-4.12.3-pyha770c72_1.conda
   sha256: fca842ab7be052eea1037ebee17ac25cc79c626382dd2187b5c6e007b9d9f65f
   md5: d48f7e9fdec44baf6d1da416fe402b04
   depends:
@@ -613,12 +552,7 @@ packages:
   - pkg:pypi/beautifulsoup4?source=hash-mapping
   size: 118042
   timestamp: 1733230951790
-- kind: conda
-  name: black
-  version: 24.10.0
-  build: py312h7900ff3_0
-  subdir: linux-64
-  url: https://conda.anaconda.org/conda-forge/linux-64/black-24.10.0-py312h7900ff3_0.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-64/black-24.10.0-py312h7900ff3_0.conda
   sha256: 2b4344d18328b3e8fd9b5356f4ee15556779766db8cb21ecf2ff818809773df6
   md5: 2daba153b913b1b901cf61440ad5e019
   depends:
@@ -635,14 +569,7 @@ packages:
   - pkg:pypi/black?source=hash-mapping
   size: 390571
   timestamp: 1728503839694
-- kind: conda
-  name: bleach
-  version: 6.2.0
-  build: pyhd8ed1ab_1
-  build_number: 1
-  subdir: noarch
-  noarch: python
-  url: https://conda.anaconda.org/conda-forge/noarch/bleach-6.2.0-pyhd8ed1ab_1.conda
+- conda: https://conda.anaconda.org/conda-forge/noarch/bleach-6.2.0-pyhd8ed1ab_1.conda
   sha256: ffc8e4e53cd92aec0f0ea0bc9e28f5fd1b1e67bde46b0b298170e6fb78eecce1
   md5: 707af59db75b066217403a8f00c1d826
   depends:
@@ -654,19 +581,12 @@ packages:
   - pkg:pypi/bleach?source=hash-mapping
   size: 132933
   timestamp: 1733302409510
-- kind: pypi
+- pypi: https://files.pythonhosted.org/packages/4b/02/8db98cdc1a58e0abd6716d5e63244658e6e63513c65f469f34b6f1053fd0/bracex-2.5.post1-py3-none-any.whl
   name: bracex
   version: 2.5.post1
-  url: https://files.pythonhosted.org/packages/4b/02/8db98cdc1a58e0abd6716d5e63244658e6e63513c65f469f34b6f1053fd0/bracex-2.5.post1-py3-none-any.whl
   sha256: 13e5732fec27828d6af308628285ad358047cec36801598368cb28bc631dbaf6
   requires_python: '>=3.8'
-- kind: conda
-  name: bracex
-  version: 2.2.1
-  build: pyhd8ed1ab_0
-  subdir: noarch
-  noarch: python
-  url: https://conda.anaconda.org/conda-forge/noarch/bracex-2.2.1-pyhd8ed1ab_0.tar.bz2
+- conda: https://conda.anaconda.org/conda-forge/noarch/bracex-2.2.1-pyhd8ed1ab_0.tar.bz2
   sha256: e3f867b5be7837366e989df8f6e64f94ec180676fea3494285ee873f24921156
   md5: 586272349d7bef5b1ef527b56dca73cb
   depends:
@@ -677,13 +597,7 @@ packages:
   - pkg:pypi/bracex?source=hash-mapping
   size: 14045
   timestamp: 1636190617443
-- kind: conda
-  name: brotli-python
-  version: 1.1.0
-  build: py312h2ec8cdc_2
-  build_number: 2
-  subdir: linux-64
-  url: https://conda.anaconda.org/conda-forge/linux-64/brotli-python-1.1.0-py312h2ec8cdc_2.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-64/brotli-python-1.1.0-py312h2ec8cdc_2.conda
   sha256: f2a59ccd20b4816dea9a2a5cb917eb69728271dbf1aeab4e1b7e609330a50b6f
   md5: b0b867af6fc74b2a0aa206da29c0f3cf
   depends:
@@ -700,10 +614,9 @@ packages:
   - pkg:pypi/brotli?source=hash-mapping
   size: 349867
   timestamp: 1725267732089
-- kind: pypi
+- pypi: https://files.pythonhosted.org/packages/84/c2/80633736cd183ee4a62107413def345f7e6e3c01563dbca1417363cf957e/build-1.2.2.post1-py3-none-any.whl
   name: build
   version: 1.2.2.post1
-  url: https://files.pythonhosted.org/packages/84/c2/80633736cd183ee4a62107413def345f7e6e3c01563dbca1417363cf957e/build-1.2.2.post1-py3-none-any.whl
   sha256: 1d61c0887fa860c01971625baae8bdd338e517b836a2f70dd1f7aa3a6b2fc5b5
   requires_dist:
   - packaging>=19.1
@@ -736,13 +649,7 @@ packages:
   - uv>=0.1.18 ; extra == 'uv'
   - virtualenv>=20.0.35 ; extra == 'virtualenv'
   requires_python: '>=3.8'
-- kind: conda
-  name: bump-my-version
-  version: 0.28.1
-  build: pyhd8ed1ab_0
-  subdir: noarch
-  noarch: python
-  url: https://conda.anaconda.org/conda-forge/noarch/bump-my-version-0.28.1-pyhd8ed1ab_0.conda
+- conda: https://conda.anaconda.org/conda-forge/noarch/bump-my-version-0.28.1-pyhd8ed1ab_0.conda
   sha256: a4935811c9833b4a58922b7f1fa6bbe7cbc7f0f477e67b4b16d515417df3b944
   md5: 27fb27016d3be886f4376c94c367c2de
   depends:
@@ -761,13 +668,7 @@ packages:
   - pkg:pypi/bump-my-version?source=hash-mapping
   size: 45642
   timestamp: 1730666890761
-- kind: conda
-  name: bzip2
-  version: 1.0.8
-  build: h4bc722e_7
-  build_number: 7
-  subdir: linux-64
-  url: https://conda.anaconda.org/conda-forge/linux-64/bzip2-1.0.8-h4bc722e_7.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-64/bzip2-1.0.8-h4bc722e_7.conda
   sha256: 5ced96500d945fb286c9c838e54fa759aa04a7129c59800f0846b4335cee770d
   md5: 62ee74e96c5ebb0af99386de58cf9553
   depends:
@@ -778,31 +679,19 @@ packages:
   purls: []
   size: 252783
   timestamp: 1720974456583
-- kind: conda
-  name: ca-certificates
-  version: 2024.8.30
-  build: hbcca054_0
-  subdir: linux-64
-  url: https://conda.anaconda.org/conda-forge/linux-64/ca-certificates-2024.8.30-hbcca054_0.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-64/ca-certificates-2024.8.30-hbcca054_0.conda
   sha256: afee721baa6d988e27fef1832f68d6f32ac8cc99cdf6015732224c2841a09cea
   md5: c27d1c142233b5bc9ca570c6e2e0c244
   license: ISC
   purls: []
   size: 159003
   timestamp: 1725018903918
-- kind: pypi
+- pypi: https://files.pythonhosted.org/packages/a5/32/8f6669fc4798494966bf446c8c4a162e0b5d893dff088afddf76414f70e1/certifi-2024.12.14-py3-none-any.whl
   name: certifi
   version: 2024.12.14
-  url: https://files.pythonhosted.org/packages/a5/32/8f6669fc4798494966bf446c8c4a162e0b5d893dff088afddf76414f70e1/certifi-2024.12.14-py3-none-any.whl
   sha256: 1275f7a45be9464efc1173084eaa30f866fe2e47d389406136d332ed4967ec56
   requires_python: '>=3.6'
-- kind: conda
-  name: certifi
-  version: 2024.8.30
-  build: pyhd8ed1ab_0
-  subdir: noarch
-  noarch: python
-  url: https://conda.anaconda.org/conda-forge/noarch/certifi-2024.8.30-pyhd8ed1ab_0.conda
+- conda: https://conda.anaconda.org/conda-forge/noarch/certifi-2024.8.30-pyhd8ed1ab_0.conda
   sha256: 7020770df338c45ac6b560185956c32f0a5abf4b76179c037f115fc7d687819f
   md5: 12f7d00853807b0531775e9be891cb11
   depends:
@@ -812,12 +701,7 @@ packages:
   - pkg:pypi/certifi?source=hash-mapping
   size: 163752
   timestamp: 1725278204397
-- kind: conda
-  name: cffi
-  version: 1.17.1
-  build: py312h06ac9bb_0
-  subdir: linux-64
-  url: https://conda.anaconda.org/conda-forge/linux-64/cffi-1.17.1-py312h06ac9bb_0.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-64/cffi-1.17.1-py312h06ac9bb_0.conda
   sha256: cba6ea83c4b0b4f5b5dc59cb19830519b28f95d7ebef7c9c5cf1c14843621457
   md5: a861504bbea4161a9170b85d4d2be840
   depends:
@@ -833,20 +717,12 @@ packages:
   - pkg:pypi/cffi?source=hash-mapping
   size: 294403
   timestamp: 1725560714366
-- kind: pypi
+- pypi: https://files.pythonhosted.org/packages/16/92/92a76dc2ff3a12e69ba94e7e05168d37d0345fa08c87e1fe24d0c2a42223/charset_normalizer-3.4.0-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.whl
   name: charset-normalizer
   version: 3.4.0
-  url: https://files.pythonhosted.org/packages/16/92/92a76dc2ff3a12e69ba94e7e05168d37d0345fa08c87e1fe24d0c2a42223/charset_normalizer-3.4.0-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.whl
   sha256: 8cda06946eac330cbe6598f77bb54e690b4ca93f593dee1568ad22b04f347c15
   requires_python: '>=3.7.0'
-- kind: conda
-  name: charset-normalizer
-  version: 3.4.0
-  build: pyhd8ed1ab_1
-  build_number: 1
-  subdir: noarch
-  noarch: python
-  url: https://conda.anaconda.org/conda-forge/noarch/charset-normalizer-3.4.0-pyhd8ed1ab_1.conda
+- conda: https://conda.anaconda.org/conda-forge/noarch/charset-normalizer-3.4.0-pyhd8ed1ab_1.conda
   sha256: 63022ee2c6a157a9f980250a66f54bdcdf5abee817348d0f9a74c2441a6fbf0e
   md5: 6581a17bba6b948bb60130026404a9d6
   depends:
@@ -857,23 +733,15 @@ packages:
   - pkg:pypi/charset-normalizer?source=hash-mapping
   size: 47533
   timestamp: 1733218182393
-- kind: pypi
+- pypi: https://files.pythonhosted.org/packages/00/2e/d53fa4befbf2cfa713304affc7ca780ce4fc1fd8710527771b58311a3229/click-8.1.7-py3-none-any.whl
   name: click
   version: 8.1.7
-  url: https://files.pythonhosted.org/packages/00/2e/d53fa4befbf2cfa713304affc7ca780ce4fc1fd8710527771b58311a3229/click-8.1.7-py3-none-any.whl
   sha256: ae74fb96c20a0277a1d615f1e4d73c8414f5a98db8b799a7931d1582f3390c28
   requires_dist:
-  - colorama ; platform_system == 'Windows'
+  - colorama ; sys_platform == 'win32'
   - importlib-metadata ; python_full_version < '3.8'
   requires_python: '>=3.7'
-- kind: conda
-  name: click
-  version: 8.1.7
-  build: unix_pyh707e725_1
-  build_number: 1
-  subdir: noarch
-  noarch: python
-  url: https://conda.anaconda.org/conda-forge/noarch/click-8.1.7-unix_pyh707e725_1.conda
+- conda: https://conda.anaconda.org/conda-forge/noarch/click-8.1.7-unix_pyh707e725_1.conda
   sha256: 1cd5fc6ccdd5141378e51252a7a3810b07fd5a7e6934a5b4a7eccba66566224b
   md5: cb8e52f28f5e592598190c562e7b5bf1
   depends:
@@ -885,14 +753,7 @@ packages:
   - pkg:pypi/click?source=hash-mapping
   size: 84513
   timestamp: 1733221925078
-- kind: conda
-  name: cloudpickle
-  version: 3.1.0
-  build: pyhd8ed1ab_1
-  build_number: 1
-  subdir: noarch
-  noarch: python
-  url: https://conda.anaconda.org/conda-forge/noarch/cloudpickle-3.1.0-pyhd8ed1ab_1.conda
+- conda: https://conda.anaconda.org/conda-forge/noarch/cloudpickle-3.1.0-pyhd8ed1ab_1.conda
   sha256: 5a33d0d3ef33121c546eaf78b3dac2141fc4d30bbaeb3959bbc66fcd5e99ced6
   md5: c88ca2bb7099167912e3b26463fff079
   depends:
@@ -903,12 +764,7 @@ packages:
   - pkg:pypi/cloudpickle?source=hash-mapping
   size: 25952
   timestamp: 1729059365471
-- kind: conda
-  name: cmarkgfm
-  version: 2024.11.20
-  build: py312h66e93f0_0
-  subdir: linux-64
-  url: https://conda.anaconda.org/conda-forge/linux-64/cmarkgfm-2024.11.20-py312h66e93f0_0.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-64/cmarkgfm-2024.11.20-py312h66e93f0_0.conda
   sha256: 294643f1ad5cbaa8646f803b89cc2da2b43c41cf4d3855883662ab0bb5455d3e
   md5: bf99b4a864e31ecd9244affd27f3ceb6
   depends:
@@ -923,14 +779,7 @@ packages:
   - pkg:pypi/cmarkgfm?source=hash-mapping
   size: 139452
   timestamp: 1732193337513
-- kind: conda
-  name: colorama
-  version: 0.4.6
-  build: pyhd8ed1ab_1
-  build_number: 1
-  subdir: noarch
-  noarch: python
-  url: https://conda.anaconda.org/conda-forge/noarch/colorama-0.4.6-pyhd8ed1ab_1.conda
+- conda: https://conda.anaconda.org/conda-forge/noarch/colorama-0.4.6-pyhd8ed1ab_1.conda
   sha256: ab29d57dc70786c1269633ba3dff20288b81664d3ff8d21af995742e2bb03287
   md5: 962b9857ee8e7018c22f2776ffa0b2d7
   depends:
@@ -941,14 +790,7 @@ packages:
   - pkg:pypi/colorama?source=hash-mapping
   size: 27011
   timestamp: 1733218222191
-- kind: conda
-  name: comm
-  version: 0.2.2
-  build: pyhd8ed1ab_1
-  build_number: 1
-  subdir: noarch
-  noarch: python
-  url: https://conda.anaconda.org/conda-forge/noarch/comm-0.2.2-pyhd8ed1ab_1.conda
+- conda: https://conda.anaconda.org/conda-forge/noarch/comm-0.2.2-pyhd8ed1ab_1.conda
   sha256: 7e87ef7c91574d9fac19faedaaee328a70f718c9b4ddadfdc0ba9ac021bd64af
   md5: 74673132601ec2b7fc592755605f4c1b
   depends:
@@ -960,12 +802,7 @@ packages:
   - pkg:pypi/comm?source=hash-mapping
   size: 12103
   timestamp: 1733503053903
-- kind: conda
-  name: coverage
-  version: 7.6.9
-  build: py312h178313f_0
-  subdir: linux-64
-  url: https://conda.anaconda.org/conda-forge/linux-64/coverage-7.6.9-py312h178313f_0.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-64/coverage-7.6.9-py312h178313f_0.conda
   sha256: 377e0ed5a3cba689622e4639d730553564df94a6ef5a0aed77ac184fbab60065
   md5: a6a5f52f8260983b0aaeebcebf558a3e
   depends:
@@ -980,12 +817,7 @@ packages:
   - pkg:pypi/coverage?source=hash-mapping
   size: 365110
   timestamp: 1733692337748
-- kind: conda
-  name: cryptography
-  version: 44.0.0
-  build: py312hda17c39_0
-  subdir: linux-64
-  url: https://conda.anaconda.org/conda-forge/linux-64/cryptography-44.0.0-py312hda17c39_0.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-64/cryptography-44.0.0-py312hda17c39_0.conda
   sha256: 4241f5e195994ae86199389b22a0621aef2afeb8a468bd98f0958bb77eff90a3
   md5: 50052304026b6f33fdd34563ee4b47b8
   depends:
@@ -1003,13 +835,7 @@ packages:
   - pkg:pypi/cryptography?source=hash-mapping
   size: 1575234
   timestamp: 1732746161385
-- kind: conda
-  name: cython
-  version: 3.0.11
-  build: py312h8fd2918_3
-  build_number: 3
-  subdir: linux-64
-  url: https://conda.anaconda.org/conda-forge/linux-64/cython-3.0.11-py312h8fd2918_3.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-64/cython-3.0.11-py312h8fd2918_3.conda
   sha256: 7a888ddda463a3146949540229c70625fbefb05bcb1352cbff990f205b8392b0
   md5: 21e433caf1bb1e4c95832f8bb731d64c
   depends:
@@ -1024,13 +850,7 @@ packages:
   - pkg:pypi/cython?source=hash-mapping
   size: 3752086
   timestamp: 1727456382070
-- kind: conda
-  name: dbus
-  version: 1.13.6
-  build: h5008d03_3
-  build_number: 3
-  subdir: linux-64
-  url: https://conda.anaconda.org/conda-forge/linux-64/dbus-1.13.6-h5008d03_3.tar.bz2
+- conda: https://conda.anaconda.org/conda-forge/linux-64/dbus-1.13.6-h5008d03_3.tar.bz2
   sha256: 8f5f995699a2d9dbdd62c61385bfeeb57c82a681a7c8c5313c395aa0ccab68a5
   md5: ecfff944ba3960ecb334b9a2663d708d
   depends:
@@ -1042,12 +862,7 @@ packages:
   purls: []
   size: 618596
   timestamp: 1640112124844
-- kind: conda
-  name: debugpy
-  version: 1.8.11
-  build: py312h2ec8cdc_0
-  subdir: linux-64
-  url: https://conda.anaconda.org/conda-forge/linux-64/debugpy-1.8.11-py312h2ec8cdc_0.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-64/debugpy-1.8.11-py312h2ec8cdc_0.conda
   sha256: 3d800be438a76d8a636219afd63a617737729867af5800d50fc72e71ac4f27f1
   md5: 0235a6da7d128c7e068973c4de62fc7b
   depends:
@@ -1062,14 +877,7 @@ packages:
   - pkg:pypi/debugpy?source=hash-mapping
   size: 2668691
   timestamp: 1734159098550
-- kind: conda
-  name: decorator
-  version: 5.1.1
-  build: pyhd8ed1ab_1
-  build_number: 1
-  subdir: noarch
-  noarch: python
-  url: https://conda.anaconda.org/conda-forge/noarch/decorator-5.1.1-pyhd8ed1ab_1.conda
+- conda: https://conda.anaconda.org/conda-forge/noarch/decorator-5.1.1-pyhd8ed1ab_1.conda
   sha256: 84e5120c97502a3785e8c3241c3bf51f64b4d445f13b4d2445db00d9816fe479
   md5: d622d8d7ee8868870f9cbe259f381181
   depends:
@@ -1080,13 +888,7 @@ packages:
   - pkg:pypi/decorator?source=hash-mapping
   size: 14068
   timestamp: 1733236549190
-- kind: conda
-  name: defusedxml
-  version: 0.7.1
-  build: pyhd8ed1ab_0
-  subdir: noarch
-  noarch: python
-  url: https://conda.anaconda.org/conda-forge/noarch/defusedxml-0.7.1-pyhd8ed1ab_0.tar.bz2
+- conda: https://conda.anaconda.org/conda-forge/noarch/defusedxml-0.7.1-pyhd8ed1ab_0.tar.bz2
   sha256: 9717a059677553562a8f38ff07f3b9f61727bd614f505658b0a5ecbcf8df89be
   md5: 961b3a227b437d82ad7054484cfa71b2
   depends:
@@ -1097,14 +899,7 @@ packages:
   - pkg:pypi/defusedxml?source=hash-mapping
   size: 24062
   timestamp: 1615232388757
-- kind: conda
-  name: docutils
-  version: 0.21.2
-  build: pyhd8ed1ab_1
-  build_number: 1
-  subdir: noarch
-  noarch: python
-  url: https://conda.anaconda.org/conda-forge/noarch/docutils-0.21.2-pyhd8ed1ab_1.conda
+- conda: https://conda.anaconda.org/conda-forge/noarch/docutils-0.21.2-pyhd8ed1ab_1.conda
   sha256: fa5966bb1718bbf6967a85075e30e4547901410cc7cb7b16daf68942e9a94823
   md5: 24c1ca34138ee57de72a943237cde4cc
   depends:
@@ -1114,14 +909,7 @@ packages:
   - pkg:pypi/docutils?source=hash-mapping
   size: 402700
   timestamp: 1733217860944
-- kind: conda
-  name: entrypoints
-  version: '0.4'
-  build: pyhd8ed1ab_1
-  build_number: 1
-  subdir: noarch
-  noarch: python
-  url: https://conda.anaconda.org/conda-forge/noarch/entrypoints-0.4-pyhd8ed1ab_1.conda
+- conda: https://conda.anaconda.org/conda-forge/noarch/entrypoints-0.4-pyhd8ed1ab_1.conda
   sha256: 80f579bfc71b3dab5bef74114b89e26c85cb0df8caf4c27ab5ffc16363d57ee7
   md5: 3366592d3c219f2731721f11bc93755c
   depends:
@@ -1132,14 +920,7 @@ packages:
   - pkg:pypi/entrypoints?source=hash-mapping
   size: 11259
   timestamp: 1733327239578
-- kind: conda
-  name: exceptiongroup
-  version: 1.2.2
-  build: pyhd8ed1ab_1
-  build_number: 1
-  subdir: noarch
-  noarch: python
-  url: https://conda.anaconda.org/conda-forge/noarch/exceptiongroup-1.2.2-pyhd8ed1ab_1.conda
+- conda: https://conda.anaconda.org/conda-forge/noarch/exceptiongroup-1.2.2-pyhd8ed1ab_1.conda
   sha256: cbde2c64ec317118fc06b223c5fd87c8a680255e7348dd60e7b292d2e103e701
   md5: a16662747cdeb9abbac74d0057cc976e
   depends:
@@ -1149,14 +930,7 @@ packages:
   - pkg:pypi/exceptiongroup?source=compressed-mapping
   size: 20486
   timestamp: 1733208916977
-- kind: conda
-  name: executing
-  version: 2.1.0
-  build: pyhd8ed1ab_1
-  build_number: 1
-  subdir: noarch
-  noarch: python
-  url: https://conda.anaconda.org/conda-forge/noarch/executing-2.1.0-pyhd8ed1ab_1.conda
+- conda: https://conda.anaconda.org/conda-forge/noarch/executing-2.1.0-pyhd8ed1ab_1.conda
   sha256: 28d25ea375ebab4bf7479228f8430db20986187b04999136ff5c722ebd32eb60
   md5: ef8b5fca76806159fc25b4f48d8737eb
   depends:
@@ -1167,12 +941,7 @@ packages:
   - pkg:pypi/executing?source=hash-mapping
   size: 28348
   timestamp: 1733569440265
-- kind: conda
-  name: expat
-  version: 2.6.4
-  build: h5888daf_0
-  subdir: linux-64
-  url: https://conda.anaconda.org/conda-forge/linux-64/expat-2.6.4-h5888daf_0.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-64/expat-2.6.4-h5888daf_0.conda
   sha256: 1848c7db9e264e3b8036ee133d570dd880422983cd20dd9585a505289606d276
   md5: 1d6afef758879ef5ee78127eb4cd2c4a
   depends:
@@ -1184,10 +953,9 @@ packages:
   purls: []
   size: 138145
   timestamp: 1730967050578
-- kind: pypi
+- pypi: https://files.pythonhosted.org/packages/b9/f8/feced7779d755758a52d1f6635d990b8d98dc0a29fa568bbe0625f18fdf3/filelock-3.16.1-py3-none-any.whl
   name: filelock
   version: 3.16.1
-  url: https://files.pythonhosted.org/packages/b9/f8/feced7779d755758a52d1f6635d990b8d98dc0a29fa568bbe0625f18fdf3/filelock-3.16.1-py3-none-any.whl
   sha256: 2082e5703d51fbf98ea75855d9d5527e33d8ff23099bec374a134febee6946b0
   requires_dist:
   - furo>=2024.8.6 ; extra == 'docs'
@@ -1204,20 +972,12 @@ packages:
   - virtualenv>=20.26.4 ; extra == 'testing'
   - typing-extensions>=4.12.2 ; python_full_version < '3.11' and extra == 'typing'
   requires_python: '>=3.8'
-- kind: pypi
+- pypi: https://files.pythonhosted.org/packages/af/f2/64b73a9bb86f5a89fb55450e97cd5c1f84a862d4ff90d9fd1a73ab0f64a5/frozenlist-1.5.0-cp312-cp312-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_17_x86_64.manylinux2014_x86_64.whl
   name: frozenlist
   version: 1.5.0
-  url: https://files.pythonhosted.org/packages/af/f2/64b73a9bb86f5a89fb55450e97cd5c1f84a862d4ff90d9fd1a73ab0f64a5/frozenlist-1.5.0-cp312-cp312-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_17_x86_64.manylinux2014_x86_64.whl
   sha256: 000a77d6034fbad9b6bb880f7ec073027908f1b40254b5d6f26210d2dab1240e
   requires_python: '>=3.8'
-- kind: conda
-  name: ghp-import
-  version: 2.1.0
-  build: pyhd8ed1ab_1
-  build_number: 1
-  subdir: noarch
-  noarch: python
-  url: https://conda.anaconda.org/conda-forge/noarch/ghp-import-2.1.0-pyhd8ed1ab_1.conda
+- conda: https://conda.anaconda.org/conda-forge/noarch/ghp-import-2.1.0-pyhd8ed1ab_1.conda
   sha256: 83c5e396a70dbf37cda6801fb20311a70c53a16e5374d3bf9891ae24aa912080
   md5: cb68db36ff7d6bf5846d9d955dc8747d
   depends:
@@ -1229,14 +989,7 @@ packages:
   - pkg:pypi/ghp-import?source=hash-mapping
   size: 16334
   timestamp: 1730194036772
-- kind: conda
-  name: gitdb
-  version: 4.0.11
-  build: pyhd8ed1ab_1
-  build_number: 1
-  subdir: noarch
-  noarch: python
-  url: https://conda.anaconda.org/conda-forge/noarch/gitdb-4.0.11-pyhd8ed1ab_1.conda
+- conda: https://conda.anaconda.org/conda-forge/noarch/gitdb-4.0.11-pyhd8ed1ab_1.conda
   sha256: a5150ca4103c3ded9f7664bd5176cf0a6f3da86886552bfd3d519826518b2a3d
   md5: 9d3a3c39dd982332dab2aac113492013
   depends:
@@ -1248,14 +1001,7 @@ packages:
   - pkg:pypi/gitdb?source=hash-mapping
   size: 52948
   timestamp: 1733236367007
-- kind: conda
-  name: gitpython
-  version: 3.1.43
-  build: pyhff2d567_1
-  build_number: 1
-  subdir: noarch
-  noarch: python
-  url: https://conda.anaconda.org/conda-forge/noarch/gitpython-3.1.43-pyhff2d567_1.conda
+- conda: https://conda.anaconda.org/conda-forge/noarch/gitpython-3.1.43-pyhff2d567_1.conda
   sha256: eb4bc75fe20aa0404ef698e08cf8864149300d96740268763b4c829baf8af571
   md5: 23867f6f9fcd2fb9e9ce6427addf01ae
   depends:
@@ -1268,13 +1014,7 @@ packages:
   - pkg:pypi/gitpython?source=hash-mapping
   size: 156841
   timestamp: 1733236771325
-- kind: conda
-  name: griffe
-  version: 1.5.1
-  build: pyhd8ed1ab_0
-  subdir: noarch
-  noarch: python
-  url: https://conda.anaconda.org/conda-forge/noarch/griffe-1.5.1-pyhd8ed1ab_0.conda
+- conda: https://conda.anaconda.org/conda-forge/noarch/griffe-1.5.1-pyhd8ed1ab_0.conda
   sha256: 591bf3247a0872b76e2cf57cbdb71762913568390f5a745fe0f3f779a16459a9
   md5: 87db2aa0738c4acc5f565388d519fb25
   depends:
@@ -1285,14 +1025,7 @@ packages:
   - pkg:pypi/griffe?source=hash-mapping
   size: 97620
   timestamp: 1729348988898
-- kind: conda
-  name: h2
-  version: 4.1.0
-  build: pyhd8ed1ab_1
-  build_number: 1
-  subdir: noarch
-  noarch: python
-  url: https://conda.anaconda.org/conda-forge/noarch/h2-4.1.0-pyhd8ed1ab_1.conda
+- conda: https://conda.anaconda.org/conda-forge/noarch/h2-4.1.0-pyhd8ed1ab_1.conda
   sha256: 843ddad410c370672a8250470697027618f104153612439076d4d7b91eeb7b5c
   md5: 825927dc7b0f287ef8d4d0011bb113b1
   depends:
@@ -1305,13 +1038,7 @@ packages:
   - pkg:pypi/h2?source=hash-mapping
   size: 52000
   timestamp: 1733298867359
-- kind: conda
-  name: hjson-py
-  version: 3.1.0
-  build: pyhd8ed1ab_0
-  subdir: noarch
-  noarch: python
-  url: https://conda.anaconda.org/conda-forge/noarch/hjson-py-3.1.0-pyhd8ed1ab_0.tar.bz2
+- conda: https://conda.anaconda.org/conda-forge/noarch/hjson-py-3.1.0-pyhd8ed1ab_0.tar.bz2
   sha256: be791a584329f061d28940b2c76dcf92fbd63305e81ec8eaf91646d4e15db84b
   md5: c30befad415322013e1e7418d7d23c56
   depends:
@@ -1322,14 +1049,7 @@ packages:
   - pkg:pypi/hjson?source=hash-mapping
   size: 45239
   timestamp: 1660536535567
-- kind: conda
-  name: hpack
-  version: 4.0.0
-  build: pyhd8ed1ab_1
-  build_number: 1
-  subdir: noarch
-  noarch: python
-  url: https://conda.anaconda.org/conda-forge/noarch/hpack-4.0.0-pyhd8ed1ab_1.conda
+- conda: https://conda.anaconda.org/conda-forge/noarch/hpack-4.0.0-pyhd8ed1ab_1.conda
   sha256: ec89b7e5b8aa2f0219f666084446e1fb7b54545861e9caa892acb24d125761b5
   md5: 2aa5ff7fa34a81b9196532c84c10d865
   depends:
@@ -1340,14 +1060,7 @@ packages:
   - pkg:pypi/hpack?source=hash-mapping
   size: 29412
   timestamp: 1733299296857
-- kind: conda
-  name: hyperframe
-  version: 6.0.1
-  build: pyhd8ed1ab_1
-  build_number: 1
-  subdir: noarch
-  noarch: python
-  url: https://conda.anaconda.org/conda-forge/noarch/hyperframe-6.0.1-pyhd8ed1ab_1.conda
+- conda: https://conda.anaconda.org/conda-forge/noarch/hyperframe-6.0.1-pyhd8ed1ab_1.conda
   sha256: e91c6ef09d076e1d9a02819cd00fa7ee18ecf30cdd667605c853980216584d1b
   md5: 566e75c90c1d0c8c459eb0ad9833dc7a
   depends:
@@ -1358,10 +1071,9 @@ packages:
   - pkg:pypi/hyperframe?source=hash-mapping
   size: 17239
   timestamp: 1733298862681
-- kind: pypi
+- pypi: https://files.pythonhosted.org/packages/76/c6/c88e154df9c4e1a2a66ccf0005a88dfb2650c1dffb6f5ce603dfbd452ce3/idna-3.10-py3-none-any.whl
   name: idna
   version: '3.10'
-  url: https://files.pythonhosted.org/packages/76/c6/c88e154df9c4e1a2a66ccf0005a88dfb2650c1dffb6f5ce603dfbd452ce3/idna-3.10-py3-none-any.whl
   sha256: 946d195a0d259cbba61165e88e65941f16e9b36ea6ddb97f00452bae8b1287d3
   requires_dist:
   - ruff>=0.6.2 ; extra == 'all'
@@ -1369,14 +1081,7 @@ packages:
   - pytest>=8.3.2 ; extra == 'all'
   - flake8>=7.1.1 ; extra == 'all'
   requires_python: '>=3.6'
-- kind: conda
-  name: idna
-  version: '3.10'
-  build: pyhd8ed1ab_1
-  build_number: 1
-  subdir: noarch
-  noarch: python
-  url: https://conda.anaconda.org/conda-forge/noarch/idna-3.10-pyhd8ed1ab_1.conda
+- conda: https://conda.anaconda.org/conda-forge/noarch/idna-3.10-pyhd8ed1ab_1.conda
   sha256: d7a472c9fd479e2e8dcb83fb8d433fce971ea369d704ece380e876f9c3494e87
   md5: 39a4f67be3286c86d696df570b1201b7
   depends:
@@ -1387,14 +1092,7 @@ packages:
   - pkg:pypi/idna?source=hash-mapping
   size: 49765
   timestamp: 1733211921194
-- kind: conda
-  name: importlib-metadata
-  version: 8.5.0
-  build: pyha770c72_1
-  build_number: 1
-  subdir: noarch
-  noarch: python
-  url: https://conda.anaconda.org/conda-forge/noarch/importlib-metadata-8.5.0-pyha770c72_1.conda
+- conda: https://conda.anaconda.org/conda-forge/noarch/importlib-metadata-8.5.0-pyha770c72_1.conda
   sha256: 13766b88fc5b23581530d3a0287c0c58ad82f60401afefab283bf158d2be55a9
   md5: 315607a3030ad5d5227e76e0733798ff
   depends:
@@ -1406,14 +1104,7 @@ packages:
   - pkg:pypi/importlib-metadata?source=compressed-mapping
   size: 28623
   timestamp: 1733223207185
-- kind: conda
-  name: importlib_resources
-  version: 6.4.5
-  build: pyhd8ed1ab_1
-  build_number: 1
-  subdir: noarch
-  noarch: python
-  url: https://conda.anaconda.org/conda-forge/noarch/importlib_resources-6.4.5-pyhd8ed1ab_1.conda
+- conda: https://conda.anaconda.org/conda-forge/noarch/importlib_resources-6.4.5-pyhd8ed1ab_1.conda
   sha256: 461199e429a3db01f0a673f8beaac5e0be75b88895952fb9183f2ab01c5c3c24
   md5: 15798fa69312d433af690c8c42b3fb36
   depends:
@@ -1427,14 +1118,7 @@ packages:
   - pkg:pypi/importlib-resources?source=hash-mapping
   size: 32701
   timestamp: 1733231441973
-- kind: conda
-  name: iniconfig
-  version: 2.0.0
-  build: pyhd8ed1ab_1
-  build_number: 1
-  subdir: noarch
-  noarch: python
-  url: https://conda.anaconda.org/conda-forge/noarch/iniconfig-2.0.0-pyhd8ed1ab_1.conda
+- conda: https://conda.anaconda.org/conda-forge/noarch/iniconfig-2.0.0-pyhd8ed1ab_1.conda
   sha256: 0ec8f4d02053cd03b0f3e63168316530949484f80e16f5e2fb199a1d117a89ca
   md5: 6837f3eff7dcea42ecd714ce1ac2b108
   depends:
@@ -1445,13 +1129,7 @@ packages:
   - pkg:pypi/iniconfig?source=hash-mapping
   size: 11474
   timestamp: 1733223232820
-- kind: conda
-  name: ipykernel
-  version: 6.29.5
-  build: pyh3099207_0
-  subdir: noarch
-  noarch: python
-  url: https://conda.anaconda.org/conda-forge/noarch/ipykernel-6.29.5-pyh3099207_0.conda
+- conda: https://conda.anaconda.org/conda-forge/noarch/ipykernel-6.29.5-pyh3099207_0.conda
   sha256: 33cfd339bb4efac56edf93474b37ddc049e08b1b4930cf036c893cc1f5a1f32a
   md5: b40131ab6a36ac2c09b7c57d4d3fbf99
   depends:
@@ -1475,13 +1153,7 @@ packages:
   - pkg:pypi/ipykernel?source=hash-mapping
   size: 119084
   timestamp: 1719845605084
-- kind: conda
-  name: ipython
-  version: 8.30.0
-  build: pyh707e725_0
-  subdir: noarch
-  noarch: python
-  url: https://conda.anaconda.org/conda-forge/noarch/ipython-8.30.0-pyh707e725_0.conda
+- conda: https://conda.anaconda.org/conda-forge/noarch/ipython-8.30.0-pyh707e725_0.conda
   sha256: 65cdc105e5effea2943d3979cc1592590c923a589009b484d07672faaf047af1
   md5: 5d6e5cb3a4b820f61b2073f0ad5431f1
   depends:
@@ -1504,14 +1176,7 @@ packages:
   - pkg:pypi/ipython?source=hash-mapping
   size: 600248
   timestamp: 1732897026255
-- kind: conda
-  name: isort
-  version: 5.13.2
-  build: pyhd8ed1ab_1
-  build_number: 1
-  subdir: noarch
-  noarch: python
-  url: https://conda.anaconda.org/conda-forge/noarch/isort-5.13.2-pyhd8ed1ab_1.conda
+- conda: https://conda.anaconda.org/conda-forge/noarch/isort-5.13.2-pyhd8ed1ab_1.conda
   sha256: 6ebf6e83c2d449760ad5c5cc344711d6404f9e3cf6952811b8678aca5a4ab01f
   md5: ef7dc847f19fe4859d5aaa33385bf509
   depends:
@@ -1523,14 +1188,7 @@ packages:
   - pkg:pypi/isort?source=hash-mapping
   size: 73545
   timestamp: 1733236278052
-- kind: conda
-  name: jaraco.classes
-  version: 3.4.0
-  build: pyhd8ed1ab_2
-  build_number: 2
-  subdir: noarch
-  noarch: python
-  url: https://conda.anaconda.org/conda-forge/noarch/jaraco.classes-3.4.0-pyhd8ed1ab_2.conda
+- conda: https://conda.anaconda.org/conda-forge/noarch/jaraco.classes-3.4.0-pyhd8ed1ab_2.conda
   sha256: 3d16a0fa55a29fe723c918a979b2ee927eb0bf9616381cdfd26fa9ea2b649546
   md5: ade6b25a6136661dadd1a43e4350b10b
   depends:
@@ -1542,13 +1200,7 @@ packages:
   - pkg:pypi/jaraco-classes?source=hash-mapping
   size: 12109
   timestamp: 1733326001034
-- kind: conda
-  name: jaraco.context
-  version: 6.0.1
-  build: pyhd8ed1ab_0
-  subdir: noarch
-  noarch: python
-  url: https://conda.anaconda.org/conda-forge/noarch/jaraco.context-6.0.1-pyhd8ed1ab_0.conda
+- conda: https://conda.anaconda.org/conda-forge/noarch/jaraco.context-6.0.1-pyhd8ed1ab_0.conda
   sha256: bfaba92cd33a0ae2488ab64a1d4e062bcf52b26a71f88292c62386ccac4789d7
   md5: bcc023a32ea1c44a790bbf1eae473486
   depends:
@@ -1560,13 +1212,7 @@ packages:
   - pkg:pypi/jaraco-context?source=hash-mapping
   size: 12483
   timestamp: 1733382698758
-- kind: conda
-  name: jaraco.functools
-  version: 4.1.0
-  build: pyhd8ed1ab_0
-  subdir: noarch
-  noarch: python
-  url: https://conda.anaconda.org/conda-forge/noarch/jaraco.functools-4.1.0-pyhd8ed1ab_0.conda
+- conda: https://conda.anaconda.org/conda-forge/noarch/jaraco.functools-4.1.0-pyhd8ed1ab_0.conda
   sha256: 61da3e37149da5c8479c21571eaec61cc4a41678ee872dcb2ff399c30878dddb
   md5: eb257d223050a5a27f5fdf5c9debc8ec
   depends:
@@ -1578,14 +1224,7 @@ packages:
   - pkg:pypi/jaraco-functools?source=hash-mapping
   size: 15545
   timestamp: 1733746481844
-- kind: conda
-  name: jedi
-  version: 0.19.2
-  build: pyhd8ed1ab_1
-  build_number: 1
-  subdir: noarch
-  noarch: python
-  url: https://conda.anaconda.org/conda-forge/noarch/jedi-0.19.2-pyhd8ed1ab_1.conda
+- conda: https://conda.anaconda.org/conda-forge/noarch/jedi-0.19.2-pyhd8ed1ab_1.conda
   sha256: 92c4d217e2dc68983f724aa983cca5464dcb929c566627b26a2511159667dba8
   md5: a4f4c5dc9b80bc50e0d3dc4e6e8f1bd9
   depends:
@@ -1596,13 +1235,7 @@ packages:
   - pkg:pypi/jedi?source=hash-mapping
   size: 843646
   timestamp: 1733300981994
-- kind: conda
-  name: jeepney
-  version: 0.8.0
-  build: pyhd8ed1ab_0
-  subdir: noarch
-  noarch: python
-  url: https://conda.anaconda.org/conda-forge/noarch/jeepney-0.8.0-pyhd8ed1ab_0.tar.bz2
+- conda: https://conda.anaconda.org/conda-forge/noarch/jeepney-0.8.0-pyhd8ed1ab_0.tar.bz2
   sha256: 16639759b811866d63315fe1391f6fb45f5478b823972f4d3d9f0392b7dd80b8
   md5: 9800ad1699b42612478755a2d26c722d
   depends:
@@ -1613,14 +1246,7 @@ packages:
   - pkg:pypi/jeepney?source=hash-mapping
   size: 36895
   timestamp: 1649085298891
-- kind: conda
-  name: jinja2
-  version: 3.1.4
-  build: pyhd8ed1ab_1
-  build_number: 1
-  subdir: noarch
-  noarch: python
-  url: https://conda.anaconda.org/conda-forge/noarch/jinja2-3.1.4-pyhd8ed1ab_1.conda
+- conda: https://conda.anaconda.org/conda-forge/noarch/jinja2-3.1.4-pyhd8ed1ab_1.conda
   sha256: 85a7169c078b8065bd9d121b0e7b99c8b88c42a411314b6ae5fcd81c48c4710a
   md5: 08cce3151bde4ecad7885bd9fb647532
   depends:
@@ -1632,10 +1258,9 @@ packages:
   - pkg:pypi/jinja2?source=hash-mapping
   size: 110963
   timestamp: 1733217424408
-- kind: pypi
+- pypi: https://files.pythonhosted.org/packages/69/4a/4f9dbeb84e8850557c02365a0eee0649abe5eb1d84af92a25731c6c0f922/jsonschema-4.23.0-py3-none-any.whl
   name: jsonschema
   version: 4.23.0
-  url: https://files.pythonhosted.org/packages/69/4a/4f9dbeb84e8850557c02365a0eee0649abe5eb1d84af92a25731c6c0f922/jsonschema-4.23.0-py3-none-any.whl
   sha256: fbadb6f8b144a8f8cf9f0b89ba94501d143e50411a1278633f56a7acf7fd5566
   requires_dist:
   - attrs>=22.2.0
@@ -1661,14 +1286,7 @@ packages:
   - uri-template ; extra == 'format-nongpl'
   - webcolors>=24.6.0 ; extra == 'format-nongpl'
   requires_python: '>=3.8'
-- kind: conda
-  name: jsonschema
-  version: 4.23.0
-  build: pyhd8ed1ab_1
-  build_number: 1
-  subdir: noarch
-  noarch: python
-  url: https://conda.anaconda.org/conda-forge/noarch/jsonschema-4.23.0-pyhd8ed1ab_1.conda
+- conda: https://conda.anaconda.org/conda-forge/noarch/jsonschema-4.23.0-pyhd8ed1ab_1.conda
   sha256: be992a99e589146f229c58fe5083e0b60551d774511c494f91fe011931bd7893
   md5: a3cead9264b331b32fe8f0aabc967522
   depends:
@@ -1685,22 +1303,14 @@ packages:
   - pkg:pypi/jsonschema?source=hash-mapping
   size: 74256
   timestamp: 1733472818764
-- kind: pypi
+- pypi: https://files.pythonhosted.org/packages/d1/0f/8910b19ac0670a0f80ce1008e5e751c4a57e14d2c4c13a482aa6079fa9d6/jsonschema_specifications-2024.10.1-py3-none-any.whl
   name: jsonschema-specifications
   version: 2024.10.1
-  url: https://files.pythonhosted.org/packages/d1/0f/8910b19ac0670a0f80ce1008e5e751c4a57e14d2c4c13a482aa6079fa9d6/jsonschema_specifications-2024.10.1-py3-none-any.whl
   sha256: a09a0680616357d9a0ecf05c12ad234479f549239d0f5b55f3deea67475da9bf
   requires_dist:
   - referencing>=0.31.0
   requires_python: '>=3.9'
-- kind: conda
-  name: jsonschema-specifications
-  version: 2024.10.1
-  build: pyhd8ed1ab_1
-  build_number: 1
-  subdir: noarch
-  noarch: python
-  url: https://conda.anaconda.org/conda-forge/noarch/jsonschema-specifications-2024.10.1-pyhd8ed1ab_1.conda
+- conda: https://conda.anaconda.org/conda-forge/noarch/jsonschema-specifications-2024.10.1-pyhd8ed1ab_1.conda
   sha256: 37127133837444cf0e6d1a95ff5a505f8214ed4e89e8e9343284840e674c6891
   md5: 3b519bc21bc80e60b456f1e62962a766
   depends:
@@ -1712,14 +1322,7 @@ packages:
   - pkg:pypi/jsonschema-specifications?source=hash-mapping
   size: 16170
   timestamp: 1733493624968
-- kind: conda
-  name: jupyter_client
-  version: 8.6.3
-  build: pyhd8ed1ab_1
-  build_number: 1
-  subdir: noarch
-  noarch: python
-  url: https://conda.anaconda.org/conda-forge/noarch/jupyter_client-8.6.3-pyhd8ed1ab_1.conda
+- conda: https://conda.anaconda.org/conda-forge/noarch/jupyter_client-8.6.3-pyhd8ed1ab_1.conda
   sha256: 19d8bd5bb2fde910ec59e081eeb59529491995ce0d653a5209366611023a0b3a
   md5: 4ebae00eae9705b0c3d6d1018a81d047
   depends:
@@ -1736,14 +1339,7 @@ packages:
   - pkg:pypi/jupyter-client?source=hash-mapping
   size: 106342
   timestamp: 1733441040958
-- kind: conda
-  name: jupyter_core
-  version: 5.7.2
-  build: pyh31011fe_1
-  build_number: 1
-  subdir: noarch
-  noarch: python
-  url: https://conda.anaconda.org/conda-forge/noarch/jupyter_core-5.7.2-pyh31011fe_1.conda
+- conda: https://conda.anaconda.org/conda-forge/noarch/jupyter_core-5.7.2-pyh31011fe_1.conda
   sha256: 732b1e8536bc22a5a174baa79842d79db2f4956d90293dd82dc1b3f6099bcccd
   md5: 0a2980dada0dd7fd0998f0342308b1b1
   depends:
@@ -1757,14 +1353,7 @@ packages:
   - pkg:pypi/jupyter-core?source=hash-mapping
   size: 57671
   timestamp: 1727163547058
-- kind: conda
-  name: jupyterlab_pygments
-  version: 0.3.0
-  build: pyhd8ed1ab_2
-  build_number: 2
-  subdir: noarch
-  noarch: python
-  url: https://conda.anaconda.org/conda-forge/noarch/jupyterlab_pygments-0.3.0-pyhd8ed1ab_2.conda
+- conda: https://conda.anaconda.org/conda-forge/noarch/jupyterlab_pygments-0.3.0-pyhd8ed1ab_2.conda
   sha256: dc24b900742fdaf1e077d9a3458fd865711de80bca95fe3c6d46610c532c6ef0
   md5: fd312693df06da3578383232528c468d
   depends:
@@ -1778,13 +1367,7 @@ packages:
   - pkg:pypi/jupyterlab-pygments?source=hash-mapping
   size: 18711
   timestamp: 1733328194037
-- kind: conda
-  name: jupytext
-  version: 1.16.4
-  build: pyh80e38bb_0
-  subdir: noarch
-  noarch: python
-  url: https://conda.anaconda.org/conda-forge/noarch/jupytext-1.16.4-pyh80e38bb_0.conda
+- conda: https://conda.anaconda.org/conda-forge/noarch/jupytext-1.16.4-pyh80e38bb_0.conda
   sha256: e0e904bcc18a3b31dc79b05f98a3fd46c9e52b27e7942856f767f0c0b815ae15
   md5: 1df7fd1594a7f2f6496ff23834a099bf
   depends:
@@ -1801,14 +1384,7 @@ packages:
   - pkg:pypi/jupytext?source=hash-mapping
   size: 104513
   timestamp: 1722332096729
-- kind: conda
-  name: keyring
-  version: 25.5.0
-  build: pyha804496_1
-  build_number: 1
-  subdir: noarch
-  noarch: python
-  url: https://conda.anaconda.org/conda-forge/noarch/keyring-25.5.0-pyha804496_1.conda
+- conda: https://conda.anaconda.org/conda-forge/noarch/keyring-25.5.0-pyha804496_1.conda
   sha256: 0f15886df2dfdd7474fc15b9bf890669cbfd0becb0072eafb9a3ba1e949d9a57
   md5: 8067b23a97d7ee4bb0fd81500ba4bbe3
   depends:
@@ -1827,12 +1403,7 @@ packages:
   - pkg:pypi/keyring?source=hash-mapping
   size: 37016
   timestamp: 1733418412922
-- kind: conda
-  name: keyutils
-  version: 1.6.1
-  build: h166bdaf_0
-  subdir: linux-64
-  url: https://conda.anaconda.org/conda-forge/linux-64/keyutils-1.6.1-h166bdaf_0.tar.bz2
+- conda: https://conda.anaconda.org/conda-forge/linux-64/keyutils-1.6.1-h166bdaf_0.tar.bz2
   sha256: 150c05a6e538610ca7c43beb3a40d65c90537497a4f6a5f4d15ec0451b6f5ebb
   md5: 30186d27e2c9fa62b45fb1476b7200e3
   depends:
@@ -1841,12 +1412,7 @@ packages:
   purls: []
   size: 117831
   timestamp: 1646151697040
-- kind: conda
-  name: krb5
-  version: 1.21.3
-  build: h659f571_0
-  subdir: linux-64
-  url: https://conda.anaconda.org/conda-forge/linux-64/krb5-1.21.3-h659f571_0.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-64/krb5-1.21.3-h659f571_0.conda
   sha256: 99df692f7a8a5c27cd14b5fb1374ee55e756631b9c3d659ed3ee60830249b238
   md5: 3f43953b7d3fb3aaa1d0d0723d91e368
   depends:
@@ -1861,13 +1427,7 @@ packages:
   purls: []
   size: 1370023
   timestamp: 1719463201255
-- kind: conda
-  name: ld_impl_linux-64
-  version: '2.43'
-  build: h712a8e2_2
-  build_number: 2
-  subdir: linux-64
-  url: https://conda.anaconda.org/conda-forge/linux-64/ld_impl_linux-64-2.43-h712a8e2_2.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-64/ld_impl_linux-64-2.43-h712a8e2_2.conda
   sha256: 7c91cea91b13f4314d125d1bedb9d03a29ebbd5080ccdea70260363424646dbe
   md5: 048b02e3962f066da18efe3a21b77672
   depends:
@@ -1879,13 +1439,8 @@ packages:
   purls: []
   size: 669211
   timestamp: 1729655358674
-- kind: conda
-  name: libblas
-  version: 3.9.0
-  build: 25_linux64_openblas
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libblas-3.9.0-25_linux64_openblas.conda
   build_number: 25
-  subdir: linux-64
-  url: https://conda.anaconda.org/conda-forge/linux-64/libblas-3.9.0-25_linux64_openblas.conda
   sha256: d6d12dc437d060f838820e9e61bf73baab651f91935ac594cf10beb9ef1b4450
   md5: 8ea26d42ca88ec5258802715fe1ee10b
   depends:
@@ -1901,13 +1456,8 @@ packages:
   purls: []
   size: 15677
   timestamp: 1729642900350
-- kind: conda
-  name: libcblas
-  version: 3.9.0
-  build: 25_linux64_openblas
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libcblas-3.9.0-25_linux64_openblas.conda
   build_number: 25
-  subdir: linux-64
-  url: https://conda.anaconda.org/conda-forge/linux-64/libcblas-3.9.0-25_linux64_openblas.conda
   sha256: ab87b0477078837c91d9cda62a9faca18fba7c57cc77aa779ae24b3ac783b5dd
   md5: 5dbd1b0fc0d01ec5e0e1fbe667281a11
   depends:
@@ -1921,13 +1471,7 @@ packages:
   purls: []
   size: 15613
   timestamp: 1729642905619
-- kind: conda
-  name: libedit
-  version: 3.1.20191231
-  build: he28a2e2_2
-  build_number: 2
-  subdir: linux-64
-  url: https://conda.anaconda.org/conda-forge/linux-64/libedit-3.1.20191231-he28a2e2_2.tar.bz2
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libedit-3.1.20191231-he28a2e2_2.tar.bz2
   sha256: a57d37c236d8f7c886e01656f4949d9dcca131d2a0728609c6f7fa338b65f1cf
   md5: 4d331e44109e3f0e19b4cb8f9b82f3e1
   depends:
@@ -1938,12 +1482,7 @@ packages:
   purls: []
   size: 123878
   timestamp: 1597616541093
-- kind: conda
-  name: libexpat
-  version: 2.6.4
-  build: h5888daf_0
-  subdir: linux-64
-  url: https://conda.anaconda.org/conda-forge/linux-64/libexpat-2.6.4-h5888daf_0.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libexpat-2.6.4-h5888daf_0.conda
   sha256: 56541b98447b58e52d824bd59d6382d609e11de1f8adf20b23143e353d2b8d26
   md5: db833e03127376d461e1e13e76f09b6c
   depends:
@@ -1956,13 +1495,7 @@ packages:
   purls: []
   size: 73304
   timestamp: 1730967041968
-- kind: conda
-  name: libffi
-  version: 3.4.2
-  build: h7f98852_5
-  build_number: 5
-  subdir: linux-64
-  url: https://conda.anaconda.org/conda-forge/linux-64/libffi-3.4.2-h7f98852_5.tar.bz2
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libffi-3.4.2-h7f98852_5.tar.bz2
   sha256: ab6e9856c21709b7b517e940ae7028ae0737546122f83c2aa5d692860c3b149e
   md5: d645c6d2ac96843a2bfaccd2d62b3ac3
   depends:
@@ -1972,13 +1505,7 @@ packages:
   purls: []
   size: 58292
   timestamp: 1636488182923
-- kind: conda
-  name: libgcc
-  version: 14.2.0
-  build: h77fa898_1
-  build_number: 1
-  subdir: linux-64
-  url: https://conda.anaconda.org/conda-forge/linux-64/libgcc-14.2.0-h77fa898_1.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libgcc-14.2.0-h77fa898_1.conda
   sha256: 53eb8a79365e58849e7b1a068d31f4f9e718dc938d6f2c03e960345739a03569
   md5: 3cb76c3f10d3bc7f1105b2fc9db984df
   depends:
@@ -1992,13 +1519,7 @@ packages:
   purls: []
   size: 848745
   timestamp: 1729027721139
-- kind: conda
-  name: libgcc-ng
-  version: 14.2.0
-  build: h69a702a_1
-  build_number: 1
-  subdir: linux-64
-  url: https://conda.anaconda.org/conda-forge/linux-64/libgcc-ng-14.2.0-h69a702a_1.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libgcc-ng-14.2.0-h69a702a_1.conda
   sha256: 3a76969c80e9af8b6e7a55090088bc41da4cffcde9e2c71b17f44d37b7cb87f7
   md5: e39480b9ca41323497b05492a63bc35b
   depends:
@@ -2008,13 +1529,7 @@ packages:
   purls: []
   size: 54142
   timestamp: 1729027726517
-- kind: conda
-  name: libgfortran
-  version: 14.2.0
-  build: h69a702a_1
-  build_number: 1
-  subdir: linux-64
-  url: https://conda.anaconda.org/conda-forge/linux-64/libgfortran-14.2.0-h69a702a_1.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libgfortran-14.2.0-h69a702a_1.conda
   sha256: fc9e7f22a17faf74da904ebfc4d88699013d2992e55505e4aa0eb01770290977
   md5: f1fd30127802683586f768875127a987
   depends:
@@ -2026,13 +1541,7 @@ packages:
   purls: []
   size: 53997
   timestamp: 1729027752995
-- kind: conda
-  name: libgfortran5
-  version: 14.2.0
-  build: hd5240d6_1
-  build_number: 1
-  subdir: linux-64
-  url: https://conda.anaconda.org/conda-forge/linux-64/libgfortran5-14.2.0-hd5240d6_1.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libgfortran5-14.2.0-hd5240d6_1.conda
   sha256: d149a37ca73611e425041f33b9d8dbed6e52ec506fe8cc1fc0ee054bddeb6d5d
   md5: 9822b874ea29af082e5d36098d25427d
   depends:
@@ -2044,12 +1553,7 @@ packages:
   purls: []
   size: 1462645
   timestamp: 1729027735353
-- kind: conda
-  name: libglib
-  version: 2.82.2
-  build: h2ff4ddf_0
-  subdir: linux-64
-  url: https://conda.anaconda.org/conda-forge/linux-64/libglib-2.82.2-h2ff4ddf_0.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libglib-2.82.2-h2ff4ddf_0.conda
   sha256: 49ee9401d483a76423461c50dcd37f91d070efaec7e4dc2828d8cdd2ce694231
   md5: 13e8e54035ddd2b91875ba399f0f7c04
   depends:
@@ -2065,13 +1569,7 @@ packages:
   purls: []
   size: 3931898
   timestamp: 1729191404130
-- kind: conda
-  name: libgomp
-  version: 14.2.0
-  build: h77fa898_1
-  build_number: 1
-  subdir: linux-64
-  url: https://conda.anaconda.org/conda-forge/linux-64/libgomp-14.2.0-h77fa898_1.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libgomp-14.2.0-h77fa898_1.conda
   sha256: 1911c29975ec99b6b906904040c855772ccb265a1c79d5d75c8ceec4ed89cd63
   md5: cc3573974587f12dda90d96e3e55a702
   depends:
@@ -2081,13 +1579,7 @@ packages:
   purls: []
   size: 460992
   timestamp: 1729027639220
-- kind: conda
-  name: libiconv
-  version: '1.17'
-  build: hd590300_2
-  build_number: 2
-  subdir: linux-64
-  url: https://conda.anaconda.org/conda-forge/linux-64/libiconv-1.17-hd590300_2.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libiconv-1.17-hd590300_2.conda
   sha256: 8ac2f6a9f186e76539439e50505d98581472fedb347a20e7d1f36429849f05c9
   md5: d66573916ffcf376178462f1b61c941e
   depends:
@@ -2096,13 +1588,8 @@ packages:
   purls: []
   size: 705775
   timestamp: 1702682170569
-- kind: conda
-  name: liblapack
-  version: 3.9.0
-  build: 25_linux64_openblas
+- conda: https://conda.anaconda.org/conda-forge/linux-64/liblapack-3.9.0-25_linux64_openblas.conda
   build_number: 25
-  subdir: linux-64
-  url: https://conda.anaconda.org/conda-forge/linux-64/liblapack-3.9.0-25_linux64_openblas.conda
   sha256: 9d1ff017714edb2d84868f0f931a4a0e7c289a971062b2ac66cfc8145df7e20e
   md5: 4dc03a53fc69371a6158d0ed37214cd3
   depends:
@@ -2116,13 +1603,7 @@ packages:
   purls: []
   size: 15608
   timestamp: 1729642910812
-- kind: conda
-  name: liblzma
-  version: 5.6.3
-  build: hb9d3cd8_1
-  build_number: 1
-  subdir: linux-64
-  url: https://conda.anaconda.org/conda-forge/linux-64/liblzma-5.6.3-hb9d3cd8_1.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-64/liblzma-5.6.3-hb9d3cd8_1.conda
   sha256: e6e425252f3839e2756e4af1ea2074dffd3396c161bf460629f9dfd6a65f15c6
   md5: 2ecf2f1c7e4e21fcfe6423a51a992d84
   depends:
@@ -2132,12 +1613,7 @@ packages:
   purls: []
   size: 111132
   timestamp: 1733407410083
-- kind: conda
-  name: libnsl
-  version: 2.0.1
-  build: hd590300_0
-  subdir: linux-64
-  url: https://conda.anaconda.org/conda-forge/linux-64/libnsl-2.0.1-hd590300_0.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libnsl-2.0.1-hd590300_0.conda
   sha256: 26d77a3bb4dceeedc2a41bd688564fe71bf2d149fdcf117049970bc02ff1add6
   md5: 30fd6e37fe21f86f4bd26d6ee73eeec7
   depends:
@@ -2147,13 +1623,7 @@ packages:
   purls: []
   size: 33408
   timestamp: 1697359010159
-- kind: conda
-  name: libopenblas
-  version: 0.3.28
-  build: pthreads_h94d23a6_1
-  build_number: 1
-  subdir: linux-64
-  url: https://conda.anaconda.org/conda-forge/linux-64/libopenblas-0.3.28-pthreads_h94d23a6_1.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libopenblas-0.3.28-pthreads_h94d23a6_1.conda
   sha256: 99ba271d8a80a1af2723f2e124ffd91d850074c0389c067e6d96d72a2dbfeabe
   md5: 62857b389e42b36b686331bec0922050
   depends:
@@ -2168,12 +1638,7 @@ packages:
   purls: []
   size: 5578513
   timestamp: 1730772671118
-- kind: conda
-  name: libsodium
-  version: 1.0.20
-  build: h4ab18f5_0
-  subdir: linux-64
-  url: https://conda.anaconda.org/conda-forge/linux-64/libsodium-1.0.20-h4ab18f5_0.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libsodium-1.0.20-h4ab18f5_0.conda
   sha256: 0105bd108f19ea8e6a78d2d994a6d4a8db16d19a41212070d2d1d48a63c34161
   md5: a587892d3c13b6621a6091be690dbca2
   depends:
@@ -2182,12 +1647,7 @@ packages:
   purls: []
   size: 205978
   timestamp: 1716828628198
-- kind: conda
-  name: libsqlite
-  version: 3.47.2
-  build: hee588c1_0
-  subdir: linux-64
-  url: https://conda.anaconda.org/conda-forge/linux-64/libsqlite-3.47.2-hee588c1_0.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libsqlite-3.47.2-hee588c1_0.conda
   sha256: 48af21ebc2cbf358976f1e0f4a0ab9e91dfc83d0ef337cf3837c6f5bc22fb352
   md5: b58da17db24b6e08bcbf8fed2fb8c915
   depends:
@@ -2198,13 +1658,7 @@ packages:
   purls: []
   size: 873551
   timestamp: 1733761824646
-- kind: conda
-  name: libstdcxx
-  version: 14.2.0
-  build: hc0a3c3a_1
-  build_number: 1
-  subdir: linux-64
-  url: https://conda.anaconda.org/conda-forge/linux-64/libstdcxx-14.2.0-hc0a3c3a_1.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libstdcxx-14.2.0-hc0a3c3a_1.conda
   sha256: 4661af0eb9bdcbb5fb33e5d0023b001ad4be828fccdcc56500059d56f9869462
   md5: 234a5554c53625688d51062645337328
   depends:
@@ -2214,13 +1668,7 @@ packages:
   purls: []
   size: 3893695
   timestamp: 1729027746910
-- kind: conda
-  name: libstdcxx-ng
-  version: 14.2.0
-  build: h4852527_1
-  build_number: 1
-  subdir: linux-64
-  url: https://conda.anaconda.org/conda-forge/linux-64/libstdcxx-ng-14.2.0-h4852527_1.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libstdcxx-ng-14.2.0-h4852527_1.conda
   sha256: 25bb30b827d4f6d6f0522cc0579e431695503822f144043b93c50237017fffd8
   md5: 8371ac6457591af2cf6159439c1fd051
   depends:
@@ -2230,12 +1678,7 @@ packages:
   purls: []
   size: 54105
   timestamp: 1729027780628
-- kind: conda
-  name: libuuid
-  version: 2.38.1
-  build: h0b41bf4_0
-  subdir: linux-64
-  url: https://conda.anaconda.org/conda-forge/linux-64/libuuid-2.38.1-h0b41bf4_0.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libuuid-2.38.1-h0b41bf4_0.conda
   sha256: 787eb542f055a2b3de553614b25f09eefb0a0931b0c87dbcce6efdfd92f04f18
   md5: 40b61aab5c7ba9ff276c41cfffe6b80b
   depends:
@@ -2245,13 +1688,7 @@ packages:
   purls: []
   size: 33601
   timestamp: 1680112270483
-- kind: conda
-  name: libxcrypt
-  version: 4.4.36
-  build: hd590300_1
-  build_number: 1
-  subdir: linux-64
-  url: https://conda.anaconda.org/conda-forge/linux-64/libxcrypt-4.4.36-hd590300_1.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libxcrypt-4.4.36-hd590300_1.conda
   sha256: 6ae68e0b86423ef188196fff6207ed0c8195dd84273cb5623b85aa08033a410c
   md5: 5aa797f8787fe7a17d1b0821485b5adc
   depends:
@@ -2260,13 +1697,7 @@ packages:
   purls: []
   size: 100393
   timestamp: 1702724383534
-- kind: conda
-  name: libzlib
-  version: 1.3.1
-  build: hb9d3cd8_2
-  build_number: 2
-  subdir: linux-64
-  url: https://conda.anaconda.org/conda-forge/linux-64/libzlib-1.3.1-hb9d3cd8_2.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libzlib-1.3.1-hb9d3cd8_2.conda
   sha256: d4bfe88d7cb447768e31650f06257995601f89076080e76df55e3112d4e47dc4
   md5: edb0dca6bc32e4f4789199455a1dbeb8
   depends:
@@ -2279,13 +1710,7 @@ packages:
   purls: []
   size: 60963
   timestamp: 1727963148474
-- kind: conda
-  name: loguru
-  version: 0.7.2
-  build: py312h7900ff3_2
-  build_number: 2
-  subdir: linux-64
-  url: https://conda.anaconda.org/conda-forge/linux-64/loguru-0.7.2-py312h7900ff3_2.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-64/loguru-0.7.2-py312h7900ff3_2.conda
   sha256: e5477e3fa7b4ef070e9ecae619cfc5845e14e3cdac8fbb2d158a03d51f967bef
   md5: fddd3092f921be8e01b18f2a0266d98f
   depends:
@@ -2297,13 +1722,7 @@ packages:
   - pkg:pypi/loguru?source=hash-mapping
   size: 123047
   timestamp: 1725349857430
-- kind: conda
-  name: markdown
-  version: '3.6'
-  build: pyhd8ed1ab_0
-  subdir: noarch
-  noarch: python
-  url: https://conda.anaconda.org/conda-forge/noarch/markdown-3.6-pyhd8ed1ab_0.conda
+- conda: https://conda.anaconda.org/conda-forge/noarch/markdown-3.6-pyhd8ed1ab_0.conda
   sha256: fce1fde00359696983989699c00f9891194c4ebafea647a8d21b7e2e3329b56e
   md5: 06e9bebf748a0dea03ecbe1f0e27e909
   depends:
@@ -2315,14 +1734,7 @@ packages:
   - pkg:pypi/markdown?source=hash-mapping
   size: 78331
   timestamp: 1710435316163
-- kind: conda
-  name: markdown-it-py
-  version: 3.0.0
-  build: pyhd8ed1ab_1
-  build_number: 1
-  subdir: noarch
-  noarch: python
-  url: https://conda.anaconda.org/conda-forge/noarch/markdown-it-py-3.0.0-pyhd8ed1ab_1.conda
+- conda: https://conda.anaconda.org/conda-forge/noarch/markdown-it-py-3.0.0-pyhd8ed1ab_1.conda
   sha256: 0fbacdfb31e55964152b24d5567e9a9996e1e7902fb08eb7d91b5fd6ce60803a
   md5: fee3164ac23dfca50cfcc8b85ddefb81
   depends:
@@ -2334,13 +1746,7 @@ packages:
   - pkg:pypi/markdown-it-py?source=hash-mapping
   size: 64430
   timestamp: 1733250550053
-- kind: conda
-  name: markupsafe
-  version: 3.0.2
-  build: py312h178313f_1
-  build_number: 1
-  subdir: linux-64
-  url: https://conda.anaconda.org/conda-forge/linux-64/markupsafe-3.0.2-py312h178313f_1.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-64/markupsafe-3.0.2-py312h178313f_1.conda
   sha256: 4a6bf68d2a2b669fecc9a4a009abd1cf8e72c2289522ff00d81b5a6e51ae78f5
   md5: eb227c3e0bf58f5bd69c0532b157975b
   depends:
@@ -2356,23 +1762,15 @@ packages:
   - pkg:pypi/markupsafe?source=hash-mapping
   size: 24604
   timestamp: 1733219911494
-- kind: pypi
+- pypi: https://files.pythonhosted.org/packages/48/9d/797d595dc57bbcb6284584ca7e228ac54b421aa1e864cec15d0f78e02f4b/material_plausible_plugin-0.2.0-py3-none-any.whl
   name: material-plausible-plugin
   version: 0.2.0
-  url: https://files.pythonhosted.org/packages/48/9d/797d595dc57bbcb6284584ca7e228ac54b421aa1e864cec15d0f78e02f4b/material_plausible_plugin-0.2.0-py3-none-any.whl
   sha256: b7dc866b358475d940c5c61f56f86c400b9c1e73ffa2b06819207df38f34fcf4
   requires_dist:
   - mkdocs
   - mkdocs-material
   requires_python: '>=3.7'
-- kind: conda
-  name: matplotlib-inline
-  version: 0.1.7
-  build: pyhd8ed1ab_1
-  build_number: 1
-  subdir: noarch
-  noarch: python
-  url: https://conda.anaconda.org/conda-forge/noarch/matplotlib-inline-0.1.7-pyhd8ed1ab_1.conda
+- conda: https://conda.anaconda.org/conda-forge/noarch/matplotlib-inline-0.1.7-pyhd8ed1ab_1.conda
   sha256: 69b7dc7131703d3d60da9b0faa6dd8acbf6f6c396224cf6aef3e855b8c0c41c6
   md5: af6ab708897df59bd6e7283ceab1b56b
   depends:
@@ -2384,14 +1782,7 @@ packages:
   - pkg:pypi/matplotlib-inline?source=hash-mapping
   size: 14467
   timestamp: 1733417051523
-- kind: conda
-  name: mdit-py-plugins
-  version: 0.4.2
-  build: pyhd8ed1ab_1
-  build_number: 1
-  subdir: noarch
-  noarch: python
-  url: https://conda.anaconda.org/conda-forge/noarch/mdit-py-plugins-0.4.2-pyhd8ed1ab_1.conda
+- conda: https://conda.anaconda.org/conda-forge/noarch/mdit-py-plugins-0.4.2-pyhd8ed1ab_1.conda
   sha256: c63ed79d9745109c0a70397713b0c07f06e7d3561abcb122cfc80a141ab3b449
   md5: af2060041d4f3250a7eb6ab3ec0e549b
   depends:
@@ -2403,14 +1794,7 @@ packages:
   - pkg:pypi/mdit-py-plugins?source=hash-mapping
   size: 42180
   timestamp: 1733854816517
-- kind: conda
-  name: mdurl
-  version: 0.1.2
-  build: pyhd8ed1ab_1
-  build_number: 1
-  subdir: noarch
-  noarch: python
-  url: https://conda.anaconda.org/conda-forge/noarch/mdurl-0.1.2-pyhd8ed1ab_1.conda
+- conda: https://conda.anaconda.org/conda-forge/noarch/mdurl-0.1.2-pyhd8ed1ab_1.conda
   sha256: 78c1bbe1723449c52b7a9df1af2ee5f005209f67e40b6e1d3c7619127c43b1c7
   md5: 592132998493b3ff25fd7479396e8351
   depends:
@@ -2421,14 +1805,7 @@ packages:
   - pkg:pypi/mdurl?source=hash-mapping
   size: 14465
   timestamp: 1733255681319
-- kind: conda
-  name: mergedeep
-  version: 1.3.4
-  build: pyhd8ed1ab_1
-  build_number: 1
-  subdir: noarch
-  noarch: python
-  url: https://conda.anaconda.org/conda-forge/noarch/mergedeep-1.3.4-pyhd8ed1ab_1.conda
+- conda: https://conda.anaconda.org/conda-forge/noarch/mergedeep-1.3.4-pyhd8ed1ab_1.conda
   sha256: e5b555fd638334a253d83df14e3c913ef8ce10100090e17fd6fb8e752d36f95d
   md5: d9a8fc1f01deae61735c88ec242e855c
   depends:
@@ -2439,14 +1816,7 @@ packages:
   - pkg:pypi/mergedeep?source=hash-mapping
   size: 11676
   timestamp: 1734157119152
-- kind: conda
-  name: mistune
-  version: 3.0.2
-  build: pyhd8ed1ab_1
-  build_number: 1
-  subdir: noarch
-  noarch: python
-  url: https://conda.anaconda.org/conda-forge/noarch/mistune-3.0.2-pyhd8ed1ab_1.conda
+- conda: https://conda.anaconda.org/conda-forge/noarch/mistune-3.0.2-pyhd8ed1ab_1.conda
   sha256: 0a9faaf1692b74f321cedbd37a44f108a1ec3f5d9638bc5bbf860cb3b6ff6db4
   md5: c46df05cae629e55426773ac1f85d68f
   depends:
@@ -2457,13 +1827,7 @@ packages:
   - pkg:pypi/mistune?source=hash-mapping
   size: 65901
   timestamp: 1733258822603
-- kind: conda
-  name: mkdocs
-  version: 1.6.1
-  build: pyhd8ed1ab_0
-  subdir: noarch
-  noarch: python
-  url: https://conda.anaconda.org/conda-forge/noarch/mkdocs-1.6.1-pyhd8ed1ab_0.conda
+- conda: https://conda.anaconda.org/conda-forge/noarch/mkdocs-1.6.1-pyhd8ed1ab_0.conda
   sha256: 757f046175d031781e9ae58f2c3b8f952bda157a7659a1bb59b8572ac939b40c
   md5: b7b2cfed0691bc312988b7c5bbe77226
   depends:
@@ -2490,14 +1854,7 @@ packages:
   - pkg:pypi/mkdocs?source=hash-mapping
   size: 3522125
   timestamp: 1725058594628
-- kind: conda
-  name: mkdocs-autorefs
-  version: 1.2.0
-  build: pyhd8ed1ab_1
-  build_number: 1
-  subdir: noarch
-  noarch: python
-  url: https://conda.anaconda.org/conda-forge/noarch/mkdocs-autorefs-1.2.0-pyhd8ed1ab_1.conda
+- conda: https://conda.anaconda.org/conda-forge/noarch/mkdocs-autorefs-1.2.0-pyhd8ed1ab_1.conda
   sha256: 5d26e5e5257909e03b2c59fdda7842cadc51a5e3c34b7f709ff593d5bab634e1
   md5: 43688b5c2118511e37e8fd03c1c580a2
   depends:
@@ -2511,23 +1868,16 @@ packages:
   - pkg:pypi/mkdocs-autorefs?source=hash-mapping
   size: 24228
   timestamp: 1725295211203
-- kind: pypi
+- pypi: https://files.pythonhosted.org/packages/97/f0/1434593be83f8c9b3c5cdfa3db2b3b4b8af3eab164a787ad81b5736abcf0/mkdocs_awesome_pages_plugin-2.9.3-py3-none-any.whl
   name: mkdocs-awesome-pages-plugin
   version: 2.9.3
-  url: https://files.pythonhosted.org/packages/97/f0/1434593be83f8c9b3c5cdfa3db2b3b4b8af3eab164a787ad81b5736abcf0/mkdocs_awesome_pages_plugin-2.9.3-py3-none-any.whl
   sha256: 1ba433d4e7edaf8661b15b93267f78f78e2e06ca590fc0e651ea36b191d64ae4
   requires_dist:
   - mkdocs>=1
   - natsort>=8.1.0
   - wcmatch>=7
   requires_python: '>=3.8.1'
-- kind: conda
-  name: mkdocs-gen-files
-  version: 0.4.0
-  build: pyhd8ed1ab_0
-  subdir: noarch
-  noarch: python
-  url: https://conda.anaconda.org/conda-forge/noarch/mkdocs-gen-files-0.4.0-pyhd8ed1ab_0.tar.bz2
+- conda: https://conda.anaconda.org/conda-forge/noarch/mkdocs-gen-files-0.4.0-pyhd8ed1ab_0.tar.bz2
   sha256: f158e2239b0b4549dc5e0d38c973135e19f8def084f0d096faf2c6161d12b1a9
   md5: ea350040131e9a179817f620a704411a
   depends:
@@ -2539,13 +1889,7 @@ packages:
   - pkg:pypi/mkdocs-gen-files?source=hash-mapping
   size: 12043
   timestamp: 1661211107053
-- kind: conda
-  name: mkdocs-get-deps
-  version: 0.2.0
-  build: pyhd8ed1ab_0
-  subdir: noarch
-  noarch: python
-  url: https://conda.anaconda.org/conda-forge/noarch/mkdocs-get-deps-0.2.0-pyhd8ed1ab_0.conda
+- conda: https://conda.anaconda.org/conda-forge/noarch/mkdocs-get-deps-0.2.0-pyhd8ed1ab_0.conda
   sha256: aa6207994b15a15b5f82a442804c279bf78f6c4680f0903fb015294c41e34b30
   md5: 0365c9a6e4e41732bde159112b0aef4d
   depends:
@@ -2560,13 +1904,7 @@ packages:
   - pkg:pypi/mkdocs-get-deps?source=hash-mapping
   size: 14733
   timestamp: 1713710951974
-- kind: conda
-  name: mkdocs-git-revision-date-localized-plugin
-  version: 1.2.9
-  build: pyhd8ed1ab_0
-  subdir: noarch
-  noarch: python
-  url: https://conda.anaconda.org/conda-forge/noarch/mkdocs-git-revision-date-localized-plugin-1.2.9-pyhd8ed1ab_0.conda
+- conda: https://conda.anaconda.org/conda-forge/noarch/mkdocs-git-revision-date-localized-plugin-1.2.9-pyhd8ed1ab_0.conda
   sha256: a82d131b27c4cd9e2be71326b3c6a65bbadee23dcef80f8319831c852604ff94
   md5: a331f7234c4e8f6136d12fe82f1ee7cd
   depends:
@@ -2580,13 +1918,7 @@ packages:
   - pkg:pypi/mkdocs-git-revision-date-localized-plugin?source=hash-mapping
   size: 25456
   timestamp: 1726153706839
-- kind: conda
-  name: mkdocs-glightbox
-  version: 0.4.0
-  build: pyhd8ed1ab_0
-  subdir: noarch
-  noarch: python
-  url: https://conda.anaconda.org/conda-forge/noarch/mkdocs-glightbox-0.4.0-pyhd8ed1ab_0.conda
+- conda: https://conda.anaconda.org/conda-forge/noarch/mkdocs-glightbox-0.4.0-pyhd8ed1ab_0.conda
   sha256: 63a7e757ea96166793d2ae8a5c0c0759169b168b088ba89b53dd4305a433cf14
   md5: bd45af24c992ba48cbbe12f251d9215e
   depends:
@@ -2597,13 +1929,7 @@ packages:
   - pkg:pypi/mkdocs-glightbox?source=hash-mapping
   size: 30948
   timestamp: 1715044596241
-- kind: conda
-  name: mkdocs-jupyter
-  version: 0.25.1
-  build: pyhd8ed1ab_0
-  subdir: noarch
-  noarch: python
-  url: https://conda.anaconda.org/conda-forge/noarch/mkdocs-jupyter-0.25.1-pyhd8ed1ab_0.conda
+- conda: https://conda.anaconda.org/conda-forge/noarch/mkdocs-jupyter-0.25.1-pyhd8ed1ab_0.conda
   sha256: 026ee6d726e7fa6e375823903318b702eb5751eec30f45bed8e607b36fc66569
   md5: 1b225a74ce9e55ded554e1dac6da89fa
   depends:
@@ -2620,13 +1946,7 @@ packages:
   - pkg:pypi/mkdocs-jupyter?source=hash-mapping
   size: 1193680
   timestamp: 1731435601843
-- kind: conda
-  name: mkdocs-macros-plugin
-  version: 1.3.7
-  build: pyhd8ed1ab_0
-  subdir: noarch
-  noarch: python
-  url: https://conda.anaconda.org/conda-forge/noarch/mkdocs-macros-plugin-1.3.7-pyhd8ed1ab_0.conda
+- conda: https://conda.anaconda.org/conda-forge/noarch/mkdocs-macros-plugin-1.3.7-pyhd8ed1ab_0.conda
   sha256: df27ad6a7ec7086e95d624443b19618c18c75f6b7f41835293b4ea406e112c50
   md5: 7ed9e7512c1e96a318afe0011e89e8f8
   depends:
@@ -2646,13 +1966,7 @@ packages:
   - pkg:pypi/mkdocs-macros-plugin?source=hash-mapping
   size: 34810
   timestamp: 1729967508816
-- kind: conda
-  name: mkdocs-material
-  version: 9.5.48
-  build: pyhd8ed1ab_0
-  subdir: noarch
-  noarch: python
-  url: https://conda.anaconda.org/conda-forge/noarch/mkdocs-material-9.5.48-pyhd8ed1ab_0.conda
+- conda: https://conda.anaconda.org/conda-forge/noarch/mkdocs-material-9.5.48-pyhd8ed1ab_0.conda
   sha256: 28bca703b95a7c367c48c4f97fe64a98dd7ad7c1c8d235ce160f27d5901edd58
   md5: ebe34a572984b7186fa46c32d5f33cca
   depends:
@@ -2675,13 +1989,7 @@ packages:
   - pkg:pypi/mkdocs-material?source=hash-mapping
   size: 4888534
   timestamp: 1733780218029
-- kind: conda
-  name: mkdocs-material-extensions
-  version: 1.3.1
-  build: pyhd8ed1ab_0
-  subdir: noarch
-  noarch: python
-  url: https://conda.anaconda.org/conda-forge/noarch/mkdocs-material-extensions-1.3.1-pyhd8ed1ab_0.conda
+- conda: https://conda.anaconda.org/conda-forge/noarch/mkdocs-material-extensions-1.3.1-pyhd8ed1ab_0.conda
   sha256: e01a349f4816ba7513f8b230ca2c4f703a7ccc7f7d78535076f9215ca766ec78
   md5: 6e7e399b351756b9d181c64a362bdcb5
   depends:
@@ -2694,13 +2002,7 @@ packages:
   - pkg:pypi/mkdocs-material-extensions?source=hash-mapping
   size: 16011
   timestamp: 1700695213251
-- kind: conda
-  name: mkdocs-table-reader-plugin
-  version: 3.1.0
-  build: pyhd8ed1ab_0
-  subdir: noarch
-  noarch: python
-  url: https://conda.anaconda.org/conda-forge/noarch/mkdocs-table-reader-plugin-3.1.0-pyhd8ed1ab_0.conda
+- conda: https://conda.anaconda.org/conda-forge/noarch/mkdocs-table-reader-plugin-3.1.0-pyhd8ed1ab_0.conda
   sha256: 2d81889f195ed4ac50128a7485e7dfa65e692e71721913617796141e02ff02b4
   md5: 027d48d01eb97a1175c66d6ac8f24ff8
   depends:
@@ -2715,13 +2017,7 @@ packages:
   - pkg:pypi/mkdocs-table-reader-plugin?source=hash-mapping
   size: 15076
   timestamp: 1724961317361
-- kind: conda
-  name: mkdocstrings
-  version: 0.26.2
-  build: pyhd8ed1ab_0
-  subdir: noarch
-  noarch: python
-  url: https://conda.anaconda.org/conda-forge/noarch/mkdocstrings-0.26.2-pyhd8ed1ab_0.conda
+- conda: https://conda.anaconda.org/conda-forge/noarch/mkdocstrings-0.26.2-pyhd8ed1ab_0.conda
   sha256: 95622541e9a96ca539e379a17008a6224b05516ede3d544412f63a050f320fc2
   md5: dbb0e345753ce3932f097d57a7ba2344
   depends:
@@ -2741,13 +2037,7 @@ packages:
   - pkg:pypi/mkdocstrings?source=hash-mapping
   size: 30546
   timestamp: 1728841500652
-- kind: conda
-  name: mkdocstrings-python
-  version: 1.12.2
-  build: pyhff2d567_0
-  subdir: noarch
-  noarch: python
-  url: https://conda.anaconda.org/conda-forge/noarch/mkdocstrings-python-1.12.2-pyhff2d567_0.conda
+- conda: https://conda.anaconda.org/conda-forge/noarch/mkdocstrings-python-1.12.2-pyhff2d567_0.conda
   sha256: 25b01f86e5aca97eede0057b1bd7feb2b91719dab0930fe222f16ce7ad38c893
   md5: d10758f0e39897d7d2fa4b399370a3b1
   depends:
@@ -2760,14 +2050,7 @@ packages:
   - pkg:pypi/mkdocstrings-python?source=hash-mapping
   size: 48611
   timestamp: 1729546255258
-- kind: conda
-  name: more-itertools
-  version: 10.5.0
-  build: pyhd8ed1ab_1
-  build_number: 1
-  subdir: noarch
-  noarch: python
-  url: https://conda.anaconda.org/conda-forge/noarch/more-itertools-10.5.0-pyhd8ed1ab_1.conda
+- conda: https://conda.anaconda.org/conda-forge/noarch/more-itertools-10.5.0-pyhd8ed1ab_1.conda
   sha256: ccb385f3a25efb47e9ea9870b0fa67b05c3b40c4c695e5f3946ab12e79e3096d
   md5: 206f67a1eccc290e5679bb793c3eb17e
   depends:
@@ -2778,18 +2061,12 @@ packages:
   - pkg:pypi/more-itertools?source=hash-mapping
   size: 57541
   timestamp: 1733662695649
-- kind: pypi
+- pypi: https://files.pythonhosted.org/packages/f1/54/65af8de681fa8255402c80eda2a501ba467921d5a7a028c9c22a2c2eedb5/msgpack-1.1.0-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.whl
   name: msgpack
   version: 1.1.0
-  url: https://files.pythonhosted.org/packages/f1/54/65af8de681fa8255402c80eda2a501ba467921d5a7a028c9c22a2c2eedb5/msgpack-1.1.0-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.whl
   sha256: 17fb65dd0bec285907f68b15734a993ad3fc94332b5bb21b0435846228de1f39
   requires_python: '>=3.8'
-- kind: conda
-  name: mypy
-  version: 1.13.0
-  build: py312h66e93f0_0
-  subdir: linux-64
-  url: https://conda.anaconda.org/conda-forge/linux-64/mypy-1.13.0-py312h66e93f0_0.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-64/mypy-1.13.0-py312h66e93f0_0.conda
   sha256: fbd1a5ac0e0e0fb16ab65395fb9b6d86aa9fb1e32689df13ee45829294a7ec57
   md5: 824a5a98260d4ee4d12fcad92d153c47
   depends:
@@ -2806,14 +2083,7 @@ packages:
   - pkg:pypi/mypy?source=hash-mapping
   size: 18799862
   timestamp: 1729644961295
-- kind: conda
-  name: mypy_extensions
-  version: 1.0.0
-  build: pyha770c72_1
-  build_number: 1
-  subdir: noarch
-  noarch: python
-  url: https://conda.anaconda.org/conda-forge/noarch/mypy_extensions-1.0.0-pyha770c72_1.conda
+- conda: https://conda.anaconda.org/conda-forge/noarch/mypy_extensions-1.0.0-pyha770c72_1.conda
   sha256: 1895f47b7d68581a6facde5cb13ab8c2764c2e53a76bd746f8f98910dc4e08fe
   md5: 29097e7ea634a45cc5386b95cac6568f
   depends:
@@ -2824,22 +2094,15 @@ packages:
   - pkg:pypi/mypy-extensions?source=hash-mapping
   size: 10854
   timestamp: 1733230986902
-- kind: pypi
+- pypi: https://files.pythonhosted.org/packages/ef/82/7a9d0550484a62c6da82858ee9419f3dd1ccc9aa1c26a1e43da3ecd20b0d/natsort-8.4.0-py3-none-any.whl
   name: natsort
   version: 8.4.0
-  url: https://files.pythonhosted.org/packages/ef/82/7a9d0550484a62c6da82858ee9419f3dd1ccc9aa1c26a1e43da3ecd20b0d/natsort-8.4.0-py3-none-any.whl
   sha256: 4732914fb471f56b5cce04d7bae6f164a592c7712e1c85f9ef585e197299521c
   requires_dist:
   - fastnumbers>=2.0.0 ; extra == 'fast'
   - pyicu>=1.0.0 ; extra == 'icu'
   requires_python: '>=3.7'
-- kind: conda
-  name: nbclient
-  version: 0.10.1
-  build: pyhd8ed1ab_0
-  subdir: noarch
-  noarch: python
-  url: https://conda.anaconda.org/conda-forge/noarch/nbclient-0.10.1-pyhd8ed1ab_0.conda
+- conda: https://conda.anaconda.org/conda-forge/noarch/nbclient-0.10.1-pyhd8ed1ab_0.conda
   sha256: 564e22c4048f2f00c7ee79417dea364f95cf069a1f2565dc26d5ece1fc3fd779
   md5: 3ee79082e59a28e1db11e2a9c3bcd85a
   depends:
@@ -2854,14 +2117,7 @@ packages:
   - pkg:pypi/nbclient?source=hash-mapping
   size: 27878
   timestamp: 1732882434219
-- kind: conda
-  name: nbconvert
-  version: 7.16.4
-  build: hd8ed1ab_2
-  build_number: 2
-  subdir: noarch
-  noarch: generic
-  url: https://conda.anaconda.org/conda-forge/noarch/nbconvert-7.16.4-hd8ed1ab_2.conda
+- conda: https://conda.anaconda.org/conda-forge/noarch/nbconvert-7.16.4-hd8ed1ab_2.conda
   sha256: 034ae98c183f260307d3a9775fa75871dd6ab00b2bce52c6cd417dd8cc86fc4a
   md5: 9337002f0dd2fcb8e1064f8023c8e0c0
   depends:
@@ -2872,14 +2128,7 @@ packages:
   purls: []
   size: 8134
   timestamp: 1733405605338
-- kind: conda
-  name: nbconvert-core
-  version: 7.16.4
-  build: pyhff2d567_2
-  build_number: 2
-  subdir: noarch
-  noarch: python
-  url: https://conda.anaconda.org/conda-forge/noarch/nbconvert-core-7.16.4-pyhff2d567_2.conda
+- conda: https://conda.anaconda.org/conda-forge/noarch/nbconvert-core-7.16.4-pyhff2d567_2.conda
   sha256: 03a1303ce135a8214b450e751d93c9048f55edb37f3f9f06c5e9d78ba3ef2a89
   md5: 0457fdf55c88e52e0e7b63691eafcc48
   depends:
@@ -2909,14 +2158,7 @@ packages:
   - pkg:pypi/nbconvert?source=hash-mapping
   size: 188505
   timestamp: 1733405603619
-- kind: conda
-  name: nbconvert-pandoc
-  version: 7.16.4
-  build: hd8ed1ab_2
-  build_number: 2
-  subdir: noarch
-  noarch: generic
-  url: https://conda.anaconda.org/conda-forge/noarch/nbconvert-pandoc-7.16.4-hd8ed1ab_2.conda
+- conda: https://conda.anaconda.org/conda-forge/noarch/nbconvert-pandoc-7.16.4-hd8ed1ab_2.conda
   sha256: d72734dcda3ab02e76ac11d453e1d4fac7edbd37db86fe14b324b15fd84ce42c
   md5: 28701f71ce0b88b86783df822dd9d7b9
   depends:
@@ -2927,14 +2169,7 @@ packages:
   purls: []
   size: 8171
   timestamp: 1733405604621
-- kind: conda
-  name: nbformat
-  version: 5.10.4
-  build: pyhd8ed1ab_1
-  build_number: 1
-  subdir: noarch
-  noarch: python
-  url: https://conda.anaconda.org/conda-forge/noarch/nbformat-5.10.4-pyhd8ed1ab_1.conda
+- conda: https://conda.anaconda.org/conda-forge/noarch/nbformat-5.10.4-pyhd8ed1ab_1.conda
   sha256: 7a5bd30a2e7ddd7b85031a5e2e14f290898098dc85bea5b3a5bf147c25122838
   md5: bbe1963f1e47f594070ffe87cdf612ea
   depends:
@@ -2949,13 +2184,7 @@ packages:
   - pkg:pypi/nbformat?source=hash-mapping
   size: 100945
   timestamp: 1733402844974
-- kind: conda
-  name: ncurses
-  version: '6.5'
-  build: he02047a_1
-  build_number: 1
-  subdir: linux-64
-  url: https://conda.anaconda.org/conda-forge/linux-64/ncurses-6.5-he02047a_1.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-64/ncurses-6.5-he02047a_1.conda
   sha256: 6a1d5d8634c1a07913f1c525db6455918cbc589d745fac46d9d6e30340c8731a
   md5: 70caf8bb6cf39a0b6b7efc885f51c0fe
   depends:
@@ -2965,14 +2194,7 @@ packages:
   purls: []
   size: 889086
   timestamp: 1724658547447
-- kind: conda
-  name: nest-asyncio
-  version: 1.6.0
-  build: pyhd8ed1ab_1
-  build_number: 1
-  subdir: noarch
-  noarch: python
-  url: https://conda.anaconda.org/conda-forge/noarch/nest-asyncio-1.6.0-pyhd8ed1ab_1.conda
+- conda: https://conda.anaconda.org/conda-forge/noarch/nest-asyncio-1.6.0-pyhd8ed1ab_1.conda
   sha256: bb7b21d7fd0445ddc0631f64e66d91a179de4ba920b8381f29b9d006a42788c0
   md5: 598fd7d4d0de2455fb74f56063969a97
   depends:
@@ -2983,13 +2205,7 @@ packages:
   - pkg:pypi/nest-asyncio?source=hash-mapping
   size: 11543
   timestamp: 1733325673691
-- kind: conda
-  name: nh3
-  version: 0.2.18
-  build: py312h12e396e_1
-  build_number: 1
-  subdir: linux-64
-  url: https://conda.anaconda.org/conda-forge/linux-64/nh3-0.2.18-py312h12e396e_1.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-64/nh3-0.2.18-py312h12e396e_1.conda
   sha256: b0a67992a9a09b3cd2ab7a31728d77301783b22cf6ad4153cf2e737ac839dcb7
   md5: 7c34beca547867671e26e61106fad3bd
   depends:
@@ -3005,12 +2221,7 @@ packages:
   - pkg:pypi/nh3?source=hash-mapping
   size: 658988
   timestamp: 1725341823258
-- kind: conda
-  name: numpy
-  version: 2.2.0
-  build: py312h7e784f5_0
-  subdir: linux-64
-  url: https://conda.anaconda.org/conda-forge/linux-64/numpy-2.2.0-py312h7e784f5_0.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-64/numpy-2.2.0-py312h7e784f5_0.conda
   sha256: 288b65215e8b2872b41aa369d31c8d7a22e280e94d5704d4d92594126796a5aa
   md5: c9e9a81299192e77428f40711a4fb00d
   depends:
@@ -3030,12 +2241,7 @@ packages:
   - pkg:pypi/numpy?source=hash-mapping
   size: 8421926
   timestamp: 1733688768634
-- kind: conda
-  name: openssl
-  version: 3.4.0
-  build: hb9d3cd8_0
-  subdir: linux-64
-  url: https://conda.anaconda.org/conda-forge/linux-64/openssl-3.4.0-hb9d3cd8_0.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-64/openssl-3.4.0-hb9d3cd8_0.conda
   sha256: 814b9dff1847b132c676ee6cc1a8cb2d427320779b93e1b6d76552275c128705
   md5: 23cc74f77eb99315c0360ec3533147a9
   depends:
@@ -3047,20 +2253,12 @@ packages:
   purls: []
   size: 2947466
   timestamp: 1731377666602
-- kind: pypi
+- pypi: https://files.pythonhosted.org/packages/88/ef/eb23f262cca3c0c4eb7ab1933c3b1f03d021f2c48f54763065b6f0e321be/packaging-24.2-py3-none-any.whl
   name: packaging
   version: '24.2'
-  url: https://files.pythonhosted.org/packages/88/ef/eb23f262cca3c0c4eb7ab1933c3b1f03d021f2c48f54763065b6f0e321be/packaging-24.2-py3-none-any.whl
   sha256: 09abb1bccd265c01f4a3aa3f7a7db064b36514d2cba19a2f694fe6150451a759
   requires_python: '>=3.8'
-- kind: conda
-  name: packaging
-  version: '24.2'
-  build: pyhd8ed1ab_2
-  build_number: 2
-  subdir: noarch
-  noarch: python
-  url: https://conda.anaconda.org/conda-forge/noarch/packaging-24.2-pyhd8ed1ab_2.conda
+- conda: https://conda.anaconda.org/conda-forge/noarch/packaging-24.2-pyhd8ed1ab_2.conda
   sha256: da157b19bcd398b9804c5c52fc000fcb8ab0525bdb9c70f95beaa0bb42f85af1
   md5: 3bfed7e6228ebf2f7b9eaa47f1b4e2aa
   depends:
@@ -3071,13 +2269,7 @@ packages:
   - pkg:pypi/packaging?source=hash-mapping
   size: 60164
   timestamp: 1733203368787
-- kind: conda
-  name: paginate
-  version: 0.5.7
-  build: pyhd8ed1ab_0
-  subdir: noarch
-  noarch: python
-  url: https://conda.anaconda.org/conda-forge/noarch/paginate-0.5.7-pyhd8ed1ab_0.conda
+- conda: https://conda.anaconda.org/conda-forge/noarch/paginate-0.5.7-pyhd8ed1ab_0.conda
   sha256: 3bb17531195c52cef472e807308f0133747d9c09995aa8066798498cd297f054
   md5: 44127829a5c92252386963c8df5c192e
   depends:
@@ -3088,13 +2280,7 @@ packages:
   - pkg:pypi/paginate?source=hash-mapping
   size: 18660
   timestamp: 1724622434233
-- kind: conda
-  name: pandas
-  version: 2.2.3
-  build: py312hf9745cd_1
-  build_number: 1
-  subdir: linux-64
-  url: https://conda.anaconda.org/conda-forge/linux-64/pandas-2.2.3-py312hf9745cd_1.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-64/pandas-2.2.3-py312hf9745cd_1.conda
   sha256: ad275a83bfebfa8a8fee9b0569aaf6f513ada6a246b2f5d5b85903d8ca61887e
   md5: 8bce4f6caaf8c5448c7ac86d87e26b4b
   depends:
@@ -3114,12 +2300,7 @@ packages:
   - pkg:pypi/pandas?source=hash-mapping
   size: 15436913
   timestamp: 1726879054912
-- kind: conda
-  name: pandoc
-  version: '3.6'
-  build: ha770c72_0
-  subdir: linux-64
-  url: https://conda.anaconda.org/conda-forge/linux-64/pandoc-3.6-ha770c72_0.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-64/pandoc-3.6-ha770c72_0.conda
   sha256: 9d4cfbb4cb844c50cecb0bc3c1ad7479908f422299bf79e667aa75129c4b0a21
   md5: 38ee82616a780cf22ec6355e386e2563
   license: GPL-2.0-or-later
@@ -3127,13 +2308,7 @@ packages:
   purls: []
   size: 21236819
   timestamp: 1733818363981
-- kind: conda
-  name: pandocfilters
-  version: 1.5.0
-  build: pyhd8ed1ab_0
-  subdir: noarch
-  noarch: python
-  url: https://conda.anaconda.org/conda-forge/noarch/pandocfilters-1.5.0-pyhd8ed1ab_0.tar.bz2
+- conda: https://conda.anaconda.org/conda-forge/noarch/pandocfilters-1.5.0-pyhd8ed1ab_0.tar.bz2
   sha256: 2bb9ba9857f4774b85900c2562f7e711d08dd48e2add9bee4e1612fbee27e16f
   md5: 457c2c8c08e54905d6954e79cb5b5db9
   depends:
@@ -3144,14 +2319,7 @@ packages:
   - pkg:pypi/pandocfilters?source=hash-mapping
   size: 11627
   timestamp: 1631603397334
-- kind: conda
-  name: parso
-  version: 0.8.4
-  build: pyhd8ed1ab_1
-  build_number: 1
-  subdir: noarch
-  noarch: python
-  url: https://conda.anaconda.org/conda-forge/noarch/parso-0.8.4-pyhd8ed1ab_1.conda
+- conda: https://conda.anaconda.org/conda-forge/noarch/parso-0.8.4-pyhd8ed1ab_1.conda
   sha256: 17131120c10401a99205fc6fe436e7903c0fa092f1b3e80452927ab377239bcc
   md5: 5c092057b6badd30f75b06244ecd01c9
   depends:
@@ -3162,14 +2330,7 @@ packages:
   - pkg:pypi/parso?source=hash-mapping
   size: 75295
   timestamp: 1733271352153
-- kind: conda
-  name: pathspec
-  version: 0.12.1
-  build: pyhd8ed1ab_1
-  build_number: 1
-  subdir: noarch
-  noarch: python
-  url: https://conda.anaconda.org/conda-forge/noarch/pathspec-0.12.1-pyhd8ed1ab_1.conda
+- conda: https://conda.anaconda.org/conda-forge/noarch/pathspec-0.12.1-pyhd8ed1ab_1.conda
   sha256: 9f64009cdf5b8e529995f18e03665b03f5d07c0b17445b8badef45bde76249ee
   md5: 617f15191456cc6a13db418a275435e5
   depends:
@@ -3180,13 +2341,7 @@ packages:
   - pkg:pypi/pathspec?source=hash-mapping
   size: 41075
   timestamp: 1733233471940
-- kind: conda
-  name: pcre2
-  version: '10.44'
-  build: hba22ea6_2
-  build_number: 2
-  subdir: linux-64
-  url: https://conda.anaconda.org/conda-forge/linux-64/pcre2-10.44-hba22ea6_2.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-64/pcre2-10.44-hba22ea6_2.conda
   sha256: 1087716b399dab91cc9511d6499036ccdc53eb29a288bebcb19cf465c51d7c0d
   md5: df359c09c41cd186fffb93a2d87aa6f5
   depends:
@@ -3199,14 +2354,7 @@ packages:
   purls: []
   size: 952308
   timestamp: 1723488734144
-- kind: conda
-  name: pexpect
-  version: 4.9.0
-  build: pyhd8ed1ab_1
-  build_number: 1
-  subdir: noarch
-  noarch: python
-  url: https://conda.anaconda.org/conda-forge/noarch/pexpect-4.9.0-pyhd8ed1ab_1.conda
+- conda: https://conda.anaconda.org/conda-forge/noarch/pexpect-4.9.0-pyhd8ed1ab_1.conda
   sha256: 202af1de83b585d36445dc1fda94266697341994d1a3328fabde4989e1b3d07a
   md5: d0d408b1f18883a944376da5cf8101ea
   depends:
@@ -3217,14 +2365,7 @@ packages:
   - pkg:pypi/pexpect?source=hash-mapping
   size: 53561
   timestamp: 1733302019362
-- kind: conda
-  name: pickleshare
-  version: 0.7.5
-  build: pyhd8ed1ab_1004
-  build_number: 1004
-  subdir: noarch
-  noarch: python
-  url: https://conda.anaconda.org/conda-forge/noarch/pickleshare-0.7.5-pyhd8ed1ab_1004.conda
+- conda: https://conda.anaconda.org/conda-forge/noarch/pickleshare-0.7.5-pyhd8ed1ab_1004.conda
   sha256: e2ac3d66c367dada209fc6da43e645672364b9fd5f9d28b9f016e24b81af475b
   md5: 11a9d1d09a3615fc07c3faf79bc0b943
   depends:
@@ -3235,13 +2376,7 @@ packages:
   - pkg:pypi/pickleshare?source=hash-mapping
   size: 11748
   timestamp: 1733327448200
-- kind: conda
-  name: pip
-  version: 24.3.1
-  build: pyh8b19718_0
-  subdir: noarch
-  noarch: python
-  url: https://conda.anaconda.org/conda-forge/noarch/pip-24.3.1-pyh8b19718_0.conda
+- conda: https://conda.anaconda.org/conda-forge/noarch/pip-24.3.1-pyh8b19718_0.conda
   sha256: 499313e72e20225f84c2e9690bbaf5b952c8d7e0bf34b728278538f766b81628
   md5: 5dd546fe99b44fda83963d15f84263b7
   depends:
@@ -3254,13 +2389,7 @@ packages:
   - pkg:pypi/pip?source=hash-mapping
   size: 1243168
   timestamp: 1730203795600
-- kind: conda
-  name: pkginfo
-  version: 1.10.0
-  build: pyhd8ed1ab_0
-  subdir: noarch
-  noarch: python
-  url: https://conda.anaconda.org/conda-forge/noarch/pkginfo-1.10.0-pyhd8ed1ab_0.conda
+- conda: https://conda.anaconda.org/conda-forge/noarch/pkginfo-1.10.0-pyhd8ed1ab_0.conda
   sha256: 3e833f907039646e34d23203cd5c9cc487a451d955d8c8d6581e18a8ccef4cee
   md5: 8c6a4a704308f5d91f3a974a72db1096
   depends:
@@ -3271,14 +2400,7 @@ packages:
   - pkg:pypi/pkginfo?source=hash-mapping
   size: 28142
   timestamp: 1709561205511
-- kind: conda
-  name: pkgutil-resolve-name
-  version: 1.3.10
-  build: pyhd8ed1ab_2
-  build_number: 2
-  subdir: noarch
-  noarch: python
-  url: https://conda.anaconda.org/conda-forge/noarch/pkgutil-resolve-name-1.3.10-pyhd8ed1ab_2.conda
+- conda: https://conda.anaconda.org/conda-forge/noarch/pkgutil-resolve-name-1.3.10-pyhd8ed1ab_2.conda
   sha256: adb2dde5b4f7da70ae81309cce6188ed3286ff280355cf1931b45d91164d2ad8
   md5: 5a5870a74432aa332f7d32180633ad05
   depends:
@@ -3288,14 +2410,7 @@ packages:
   - pkg:pypi/pkgutil-resolve-name?source=hash-mapping
   size: 10693
   timestamp: 1733344619659
-- kind: conda
-  name: platformdirs
-  version: 4.3.6
-  build: pyhd8ed1ab_1
-  build_number: 1
-  subdir: noarch
-  noarch: python
-  url: https://conda.anaconda.org/conda-forge/noarch/platformdirs-4.3.6-pyhd8ed1ab_1.conda
+- conda: https://conda.anaconda.org/conda-forge/noarch/platformdirs-4.3.6-pyhd8ed1ab_1.conda
   sha256: bb50f6499e8bc1d1a26f17716c97984671121608dc0c3ecd34858112bce59a27
   md5: 577852c7e53901ddccc7e6a9959ddebe
   depends:
@@ -3306,14 +2421,7 @@ packages:
   - pkg:pypi/platformdirs?source=hash-mapping
   size: 20448
   timestamp: 1733232756001
-- kind: conda
-  name: pluggy
-  version: 1.5.0
-  build: pyhd8ed1ab_1
-  build_number: 1
-  subdir: noarch
-  noarch: python
-  url: https://conda.anaconda.org/conda-forge/noarch/pluggy-1.5.0-pyhd8ed1ab_1.conda
+- conda: https://conda.anaconda.org/conda-forge/noarch/pluggy-1.5.0-pyhd8ed1ab_1.conda
   sha256: 122433fc5318816b8c69283aaf267c73d87aa2d09ce39f64c9805c9a3b264819
   md5: e9dcbce5f45f9ee500e728ae58b605b6
   depends:
@@ -3324,11 +2432,10 @@ packages:
   - pkg:pypi/pluggy?source=hash-mapping
   size: 23595
   timestamp: 1733222855563
-- kind: pypi
+- pypi: .
   name: povme
   version: 2.2.1
-  path: .
-  sha256: 310956f7781b469b41642823edbed750bbcf38ab69435aef6efe8adb61d0116e
+  sha256: 5973bf1bd0a250bd9154e17ceec48d868742792801d6a6690ae2c3289d2618b4
   requires_dist:
   - numpy>=2.1.3,<3
   - scipy>=1.14.1,<2
@@ -3336,15 +2443,10 @@ packages:
   - pyyaml>=6.0.2,<7
   - loguru>=0.7.2,<0.8
   - ray>=2.38.0,<3
+  - pymolecule @ git+https://github.com/durrantlab/pymolecule
   requires_python: '>=3.10,<3.13'
   editable: true
-- kind: conda
-  name: prompt-toolkit
-  version: 3.0.36
-  build: pyha770c72_0
-  subdir: noarch
-  noarch: python
-  url: https://conda.anaconda.org/conda-forge/noarch/prompt-toolkit-3.0.36-pyha770c72_0.conda
+- conda: https://conda.anaconda.org/conda-forge/noarch/prompt-toolkit-3.0.36-pyha770c72_0.conda
   sha256: 6bd3626799c9467d7aa8ed5f95043e4cea614a1329580980ddcf40cfed3ee860
   md5: 4d79ec192e0bfd530a254006d123b9a6
   depends:
@@ -3358,14 +2460,7 @@ packages:
   - pkg:pypi/prompt-toolkit?source=hash-mapping
   size: 271530
   timestamp: 1670414885944
-- kind: conda
-  name: prompt-toolkit
-  version: 3.0.48
-  build: pyha770c72_1
-  build_number: 1
-  subdir: noarch
-  noarch: python
-  url: https://conda.anaconda.org/conda-forge/noarch/prompt-toolkit-3.0.48-pyha770c72_1.conda
+- conda: https://conda.anaconda.org/conda-forge/noarch/prompt-toolkit-3.0.48-pyha770c72_1.conda
   sha256: 79fb7d1eeb490d4cc1b79f781bb59fe302ae38cf0a30907ecde75a7d399796cc
   md5: 368d4aa48358439e07a97ae237491785
   depends:
@@ -3379,13 +2474,7 @@ packages:
   - pkg:pypi/prompt-toolkit?source=hash-mapping
   size: 269848
   timestamp: 1733302634979
-- kind: conda
-  name: prompt_toolkit
-  version: 3.0.36
-  build: hd8ed1ab_0
-  subdir: noarch
-  noarch: generic
-  url: https://conda.anaconda.org/conda-forge/noarch/prompt_toolkit-3.0.36-hd8ed1ab_0.conda
+- conda: https://conda.anaconda.org/conda-forge/noarch/prompt_toolkit-3.0.36-hd8ed1ab_0.conda
   sha256: 8685763bf7b3299be8b1e6fccad1282217733c8fcf1d682397323e2e08a00a68
   md5: 482c15eb65dde2f899c4d68eaa938b1d
   depends:
@@ -3395,18 +2484,12 @@ packages:
   purls: []
   size: 6372
   timestamp: 1670414891579
-- kind: pypi
+- pypi: https://files.pythonhosted.org/packages/04/52/c97c58a33b3d6c89a8138788576d372a90a6556f354799971c6b4d16d871/protobuf-5.29.1-cp38-abi3-manylinux2014_x86_64.whl
   name: protobuf
   version: 5.29.1
-  url: https://files.pythonhosted.org/packages/04/52/c97c58a33b3d6c89a8138788576d372a90a6556f354799971c6b4d16d871/protobuf-5.29.1-cp38-abi3-manylinux2014_x86_64.whl
   sha256: 8ee1461b3af56145aca2800e6a3e2f928108c749ba8feccc6f5dd0062c410c0d
   requires_python: '>=3.8'
-- kind: conda
-  name: psutil
-  version: 6.1.0
-  build: py312h66e93f0_0
-  subdir: linux-64
-  url: https://conda.anaconda.org/conda-forge/linux-64/psutil-6.1.0-py312h66e93f0_0.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-64/psutil-6.1.0-py312h66e93f0_0.conda
   sha256: 0f309b435174e037d5cfe5ed26c1c5ad8152c68cfe61af17709ec31ec3d9f096
   md5: 0524eb91d3d78d76d671c6e3cd7cee82
   depends:
@@ -3420,14 +2503,7 @@ packages:
   - pkg:pypi/psutil?source=hash-mapping
   size: 488462
   timestamp: 1729847159916
-- kind: conda
-  name: ptyprocess
-  version: 0.7.0
-  build: pyhd8ed1ab_1
-  build_number: 1
-  subdir: noarch
-  noarch: python
-  url: https://conda.anaconda.org/conda-forge/noarch/ptyprocess-0.7.0-pyhd8ed1ab_1.conda
+- conda: https://conda.anaconda.org/conda-forge/noarch/ptyprocess-0.7.0-pyhd8ed1ab_1.conda
   sha256: a7713dfe30faf17508ec359e0bc7e0983f5d94682492469bd462cdaae9c64d83
   md5: 7d9daffbb8d8e0af0f769dbbcd173a54
   depends:
@@ -3437,14 +2513,7 @@ packages:
   - pkg:pypi/ptyprocess?source=hash-mapping
   size: 19457
   timestamp: 1733302371990
-- kind: conda
-  name: pure_eval
-  version: 0.2.3
-  build: pyhd8ed1ab_1
-  build_number: 1
-  subdir: noarch
-  noarch: python
-  url: https://conda.anaconda.org/conda-forge/noarch/pure_eval-0.2.3-pyhd8ed1ab_1.conda
+- conda: https://conda.anaconda.org/conda-forge/noarch/pure_eval-0.2.3-pyhd8ed1ab_1.conda
   sha256: 71bd24600d14bb171a6321d523486f6a06f855e75e547fa0cb2a0953b02047f0
   md5: 3bfdfb8dbcdc4af1ae3f9a8eb3948f04
   depends:
@@ -3455,14 +2524,7 @@ packages:
   - pkg:pypi/pure-eval?source=hash-mapping
   size: 16668
   timestamp: 1733569518868
-- kind: conda
-  name: pycparser
-  version: '2.22'
-  build: pyh29332c3_1
-  build_number: 1
-  subdir: noarch
-  noarch: python
-  url: https://conda.anaconda.org/conda-forge/noarch/pycparser-2.22-pyh29332c3_1.conda
+- conda: https://conda.anaconda.org/conda-forge/noarch/pycparser-2.22-pyh29332c3_1.conda
   sha256: 79db7928d13fab2d892592223d7570f5061c192f27b9febd1a418427b719acc6
   md5: 12c566707c80111f9799308d9e265aef
   depends:
@@ -3473,13 +2535,7 @@ packages:
   purls: []
   size: 110100
   timestamp: 1733195786147
-- kind: conda
-  name: pydantic
-  version: 2.10.3
-  build: pyh3cfb1c2_0
-  subdir: noarch
-  noarch: python
-  url: https://conda.anaconda.org/conda-forge/noarch/pydantic-2.10.3-pyh3cfb1c2_0.conda
+- conda: https://conda.anaconda.org/conda-forge/noarch/pydantic-2.10.3-pyh3cfb1c2_0.conda
   sha256: cac9eebd3d5f8d8a497a9025d756257ddc75b8b3393e6737cb45077bd744d4f8
   md5: 194ef7f91286978521350f171b117f01
   depends:
@@ -3494,12 +2550,7 @@ packages:
   - pkg:pypi/pydantic?source=hash-mapping
   size: 317037
   timestamp: 1733316963547
-- kind: conda
-  name: pydantic-core
-  version: 2.27.1
-  build: py312h12e396e_0
-  subdir: linux-64
-  url: https://conda.anaconda.org/conda-forge/linux-64/pydantic-core-2.27.1-py312h12e396e_0.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-64/pydantic-core-2.27.1-py312h12e396e_0.conda
   sha256: c89741f4eff395f8de70975f42e1f20591f0e0870929d440af35b13399976b09
   md5: 114030cb28527db2c385f07038e914c8
   depends:
@@ -3516,13 +2567,7 @@ packages:
   - pkg:pypi/pydantic-core?source=hash-mapping
   size: 1635156
   timestamp: 1732254225040
-- kind: conda
-  name: pydantic-settings
-  version: 2.7.0
-  build: pyh3cfb1c2_0
-  subdir: noarch
-  noarch: python
-  url: https://conda.anaconda.org/conda-forge/noarch/pydantic-settings-2.7.0-pyh3cfb1c2_0.conda
+- conda: https://conda.anaconda.org/conda-forge/noarch/pydantic-settings-2.7.0-pyh3cfb1c2_0.conda
   sha256: dd1ac7c8b6a189c8aa18f6c7df019d8f6df495300a259e3fbebdb542fc955c3b
   md5: d9f19a7c4199249fa229891b573b6f9b
   depends:
@@ -3534,14 +2579,7 @@ packages:
   - pkg:pypi/pydantic-settings?source=compressed-mapping
   size: 31426
   timestamp: 1734127929720
-- kind: conda
-  name: pygments
-  version: 2.18.0
-  build: pyhd8ed1ab_1
-  build_number: 1
-  subdir: noarch
-  noarch: python
-  url: https://conda.anaconda.org/conda-forge/noarch/pygments-2.18.0-pyhd8ed1ab_1.conda
+- conda: https://conda.anaconda.org/conda-forge/noarch/pygments-2.18.0-pyhd8ed1ab_1.conda
   sha256: 0d6133545f268b2b89c2617c196fc791f365b538d4057ecd636d658c3b1e885d
   md5: b38dc0206e2a530e5c2cf11dc086b31a
   depends:
@@ -3552,13 +2590,7 @@ packages:
   - pkg:pypi/pygments?source=hash-mapping
   size: 876700
   timestamp: 1733221731178
-- kind: conda
-  name: pymdown-extensions
-  version: '10.12'
-  build: pyhd8ed1ab_0
-  subdir: noarch
-  noarch: python
-  url: https://conda.anaconda.org/conda-forge/noarch/pymdown-extensions-10.12-pyhd8ed1ab_0.conda
+- conda: https://conda.anaconda.org/conda-forge/noarch/pymdown-extensions-10.12-pyhd8ed1ab_0.conda
   sha256: a56ba3e7070c0dbfe8c435a43d75ea0faa4ec61aa158f364f5826a283925cd25
   md5: e352dc92203f360748da72357da78ed8
   depends:
@@ -3571,21 +2603,14 @@ packages:
   - pkg:pypi/pymdown-extensions?source=hash-mapping
   size: 167047
   timestamp: 1730190145267
-- kind: pypi
+- pypi: git+https://github.com/durrantlab/pymolecule.git?rev=423cf64f17c21881a1685402437bd69a81e79ccf#423cf64f17c21881a1685402437bd69a81e79ccf
   name: pymolecule
   version: 0.0.1
-  url: git+https://github.com/durrantlab/pymolecule.git@121c34103169d362f4ed2ca9207dd5555f9dc25b
   requires_dist:
   - numpy>=2.1.3,<3
   - scipy>=1.14.1,<2
-  requires_python: '>=3.12'
-- kind: conda
-  name: pynvml
-  version: 11.4.1
-  build: pyhd8ed1ab_0
-  subdir: noarch
-  noarch: python
-  url: https://conda.anaconda.org/conda-forge/noarch/pynvml-11.4.1-pyhd8ed1ab_0.tar.bz2
+  requires_python: '>=3.10'
+- conda: https://conda.anaconda.org/conda-forge/noarch/pynvml-11.4.1-pyhd8ed1ab_0.tar.bz2
   sha256: 9c9b9a7b6c0832984bb940ed6f022f20eb645a042ae69e16c72e379d42735818
   md5: c2e7773871d1b1ce247ffe19cd128c9f
   depends:
@@ -3596,20 +2621,12 @@ packages:
   - pkg:pypi/pynvml?source=hash-mapping
   size: 40913
   timestamp: 1639061705922
-- kind: pypi
+- pypi: https://files.pythonhosted.org/packages/bd/24/12818598c362d7f300f18e74db45963dbcb85150324092410c8b49405e42/pyproject_hooks-1.2.0-py3-none-any.whl
   name: pyproject-hooks
   version: 1.2.0
-  url: https://files.pythonhosted.org/packages/bd/24/12818598c362d7f300f18e74db45963dbcb85150324092410c8b49405e42/pyproject_hooks-1.2.0-py3-none-any.whl
   sha256: 9e5c6bfa8dcc30091c74b0cf803c81fdd29d94f01992a7707bc97babb1141913
   requires_python: '>=3.7'
-- kind: conda
-  name: pysocks
-  version: 1.7.1
-  build: pyha55dd90_7
-  build_number: 7
-  subdir: noarch
-  noarch: python
-  url: https://conda.anaconda.org/conda-forge/noarch/pysocks-1.7.1-pyha55dd90_7.conda
+- conda: https://conda.anaconda.org/conda-forge/noarch/pysocks-1.7.1-pyha55dd90_7.conda
   sha256: ba3b032fa52709ce0d9fd388f63d330a026754587a2f461117cac9ab73d8d0d8
   md5: 461219d1a5bd61342293efa2c0c90eac
   depends:
@@ -3621,14 +2638,7 @@ packages:
   - pkg:pypi/pysocks?source=hash-mapping
   size: 21085
   timestamp: 1733217331982
-- kind: conda
-  name: pytest
-  version: 8.3.4
-  build: pyhd8ed1ab_1
-  build_number: 1
-  subdir: noarch
-  noarch: python
-  url: https://conda.anaconda.org/conda-forge/noarch/pytest-8.3.4-pyhd8ed1ab_1.conda
+- conda: https://conda.anaconda.org/conda-forge/noarch/pytest-8.3.4-pyhd8ed1ab_1.conda
   sha256: 75245ca9d0cbd6d38bb45ec02430189a9d4c21c055c5259739d738a2298d61b3
   md5: 799ed216dc6af62520f32aa39bc1c2bb
   depends:
@@ -3647,14 +2657,7 @@ packages:
   - pkg:pypi/pytest?source=hash-mapping
   size: 259195
   timestamp: 1733217599806
-- kind: conda
-  name: pytest-cov
-  version: 6.0.0
-  build: pyhd8ed1ab_1
-  build_number: 1
-  subdir: noarch
-  noarch: python
-  url: https://conda.anaconda.org/conda-forge/noarch/pytest-cov-6.0.0-pyhd8ed1ab_1.conda
+- conda: https://conda.anaconda.org/conda-forge/noarch/pytest-cov-6.0.0-pyhd8ed1ab_1.conda
   sha256: 09acac1974e10a639415be4be326dd21fa6d66ca51a01fb71532263fba6dccf6
   md5: 79963c319d1be62c8fd3e34555816e01
   depends:
@@ -3668,13 +2671,8 @@ packages:
   - pkg:pypi/pytest-cov?source=hash-mapping
   size: 26256
   timestamp: 1733223113491
-- kind: conda
-  name: python
-  version: 3.12.8
-  build: h9e4cc4f_1_cpython
+- conda: https://conda.anaconda.org/conda-forge/linux-64/python-3.12.8-h9e4cc4f_1_cpython.conda
   build_number: 1
-  subdir: linux-64
-  url: https://conda.anaconda.org/conda-forge/linux-64/python-3.12.8-h9e4cc4f_1_cpython.conda
   sha256: 3f0e0518c992d8ccfe62b189125721309836fe48a010dc424240583e157f9ff0
   md5: 7fd2fd79436d9b473812f14e86746844
   depends:
@@ -3701,14 +2699,7 @@ packages:
   purls: []
   size: 31565686
   timestamp: 1733410597922
-- kind: conda
-  name: python-dateutil
-  version: 2.9.0.post0
-  build: pyhff2d567_1
-  build_number: 1
-  subdir: noarch
-  noarch: python
-  url: https://conda.anaconda.org/conda-forge/noarch/python-dateutil-2.9.0.post0-pyhff2d567_1.conda
+- conda: https://conda.anaconda.org/conda-forge/noarch/python-dateutil-2.9.0.post0-pyhff2d567_1.conda
   sha256: a50052536f1ef8516ed11a844f9413661829aa083304dc624c5925298d078d79
   md5: 5ba79d7c71f03c678c8ead841f347d6e
   depends:
@@ -3720,14 +2711,7 @@ packages:
   - pkg:pypi/python-dateutil?source=hash-mapping
   size: 222505
   timestamp: 1733215763718
-- kind: conda
-  name: python-dotenv
-  version: 1.0.1
-  build: pyhd8ed1ab_1
-  build_number: 1
-  subdir: noarch
-  noarch: python
-  url: https://conda.anaconda.org/conda-forge/noarch/python-dotenv-1.0.1-pyhd8ed1ab_1.conda
+- conda: https://conda.anaconda.org/conda-forge/noarch/python-dotenv-1.0.1-pyhd8ed1ab_1.conda
   sha256: 99713f6b534fef94995c6c16fd21d59f3548784e9111775d692bdc7c44678f02
   md5: e5c6ed218664802d305e79cc2d4491de
   depends:
@@ -3738,13 +2722,7 @@ packages:
   - pkg:pypi/python-dotenv?source=compressed-mapping
   size: 24215
   timestamp: 1733243277223
-- kind: conda
-  name: python-fastjsonschema
-  version: 2.21.1
-  build: pyhd8ed1ab_0
-  subdir: noarch
-  noarch: python
-  url: https://conda.anaconda.org/conda-forge/noarch/python-fastjsonschema-2.21.1-pyhd8ed1ab_0.conda
+- conda: https://conda.anaconda.org/conda-forge/noarch/python-fastjsonschema-2.21.1-pyhd8ed1ab_0.conda
   sha256: 1b09a28093071c1874862422696429d0d35bd0b8420698003ac004746c5e82a2
   md5: 38e34d2d1d9dca4fb2b9a0a04f604e2c
   depends:
@@ -3755,14 +2733,7 @@ packages:
   - pkg:pypi/fastjsonschema?source=hash-mapping
   size: 226259
   timestamp: 1733236073335
-- kind: conda
-  name: python-tzdata
-  version: '2024.2'
-  build: pyhd8ed1ab_1
-  build_number: 1
-  subdir: noarch
-  noarch: python
-  url: https://conda.anaconda.org/conda-forge/noarch/python-tzdata-2024.2-pyhd8ed1ab_1.conda
+- conda: https://conda.anaconda.org/conda-forge/noarch/python-tzdata-2024.2-pyhd8ed1ab_1.conda
   sha256: 57c9a02ec25926fb48edca59b9ede107823e5d5c473b94a0e05cc0b9a193a642
   md5: c0def296b2f6d2dd7b030c2a7f66bb1f
   depends:
@@ -3773,13 +2744,8 @@ packages:
   - pkg:pypi/tzdata?source=hash-mapping
   size: 142235
   timestamp: 1733235414217
-- kind: conda
-  name: python_abi
-  version: '3.12'
-  build: 5_cp312
+- conda: https://conda.anaconda.org/conda-forge/linux-64/python_abi-3.12-5_cp312.conda
   build_number: 5
-  subdir: linux-64
-  url: https://conda.anaconda.org/conda-forge/linux-64/python_abi-3.12-5_cp312.conda
   sha256: d10e93d759931ffb6372b45d65ff34d95c6000c61a07e298d162a3bc2accebb0
   md5: 0424ae29b104430108f5218a66db7260
   constrains:
@@ -3789,13 +2755,7 @@ packages:
   purls: []
   size: 6238
   timestamp: 1723823388266
-- kind: conda
-  name: pytz
-  version: '2024.1'
-  build: pyhd8ed1ab_0
-  subdir: noarch
-  noarch: python
-  url: https://conda.anaconda.org/conda-forge/noarch/pytz-2024.1-pyhd8ed1ab_0.conda
+- conda: https://conda.anaconda.org/conda-forge/noarch/pytz-2024.1-pyhd8ed1ab_0.conda
   sha256: 1a7d6b233f7e6e3bbcbad054c8fd51e690a67b129a899a056a5e45dd9f00cb41
   md5: 3eeeeb9e4827ace8c0c1419c85d590ad
   depends:
@@ -3806,13 +2766,7 @@ packages:
   - pkg:pypi/pytz?source=hash-mapping
   size: 188538
   timestamp: 1706886944988
-- kind: conda
-  name: pyyaml
-  version: 6.0.2
-  build: py312h66e93f0_1
-  build_number: 1
-  subdir: linux-64
-  url: https://conda.anaconda.org/conda-forge/linux-64/pyyaml-6.0.2-py312h66e93f0_1.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-64/pyyaml-6.0.2-py312h66e93f0_1.conda
   sha256: a60705971e958724168f2ebbb8ed4853067f1d3f7059843df3903e3092bbcffa
   md5: 549e5930e768548a89c23f595dac5a95
   depends:
@@ -3827,13 +2781,7 @@ packages:
   - pkg:pypi/pyyaml?source=hash-mapping
   size: 206553
   timestamp: 1725456256213
-- kind: conda
-  name: pyyaml-env-tag
-  version: '0.1'
-  build: pyhd8ed1ab_0
-  subdir: noarch
-  noarch: python
-  url: https://conda.anaconda.org/conda-forge/noarch/pyyaml-env-tag-0.1-pyhd8ed1ab_0.tar.bz2
+- conda: https://conda.anaconda.org/conda-forge/noarch/pyyaml-env-tag-0.1-pyhd8ed1ab_0.tar.bz2
   sha256: 900319483135730d9836855a807822f0500b1a239520749103e9ef9b7ba9f246
   md5: 626ed9060ddeb681ddc42bcad89156ab
   depends:
@@ -3845,13 +2793,7 @@ packages:
   - pkg:pypi/pyyaml-env-tag?source=hash-mapping
   size: 7473
   timestamp: 1624389117412
-- kind: conda
-  name: pyzmq
-  version: 26.2.0
-  build: py312hbf22597_3
-  build_number: 3
-  subdir: linux-64
-  url: https://conda.anaconda.org/conda-forge/linux-64/pyzmq-26.2.0-py312hbf22597_3.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-64/pyzmq-26.2.0-py312hbf22597_3.conda
   sha256: bc303f9b11e04a515f79cd5ad3bfa0e84b9dfec76552626d6263b38789fe6678
   md5: 746ce19f0829ec3e19c93007b1a224d3
   depends:
@@ -3868,14 +2810,7 @@ packages:
   - pkg:pypi/pyzmq?source=hash-mapping
   size: 378126
   timestamp: 1728642454632
-- kind: conda
-  name: questionary
-  version: 2.0.1
-  build: pyhd8ed1ab_1
-  build_number: 1
-  subdir: noarch
-  noarch: python
-  url: https://conda.anaconda.org/conda-forge/noarch/questionary-2.0.1-pyhd8ed1ab_1.conda
+- conda: https://conda.anaconda.org/conda-forge/noarch/questionary-2.0.1-pyhd8ed1ab_1.conda
   sha256: e1b22276ab3a33ed24b606e95099506269c09205278e4174823c51e5e4579eab
   md5: 375950ebdf7945b4d3d57fad0cbe52e6
   depends:
@@ -3887,18 +2822,17 @@ packages:
   - pkg:pypi/questionary?source=hash-mapping
   size: 29421
   timestamp: 1694359940547
-- kind: pypi
+- pypi: https://files.pythonhosted.org/packages/82/ad/2eaf308c64e39704629863720c59b82e1ceed814fca319b8585deb92bb74/ray-2.40.0-cp312-cp312-manylinux2014_x86_64.whl
   name: ray
   version: 2.40.0
-  url: https://files.pythonhosted.org/packages/82/ad/2eaf308c64e39704629863720c59b82e1ceed814fca319b8585deb92bb74/ray-2.40.0-cp312-cp312-manylinux2014_x86_64.whl
   sha256: 674755814f5692306c554cadbc24015af823dc0516e34bdef24ccac9d7a656e3
   requires_dist:
   - click>=7.0
   - filelock
   - jsonschema
-  - msgpack<2.0.0,>=1.0.0
+  - msgpack>=1.0.0,<2.0.0
   - packaging
-  - protobuf!=3.19.5,>=3.15.3
+  - protobuf>=3.15.3,!=3.19.5
   - pyyaml
   - aiosignal
   - frozenlist
@@ -3914,7 +2848,7 @@ packages:
   - pandas ; extra == 'air'
   - numpy>=1.20 ; extra == 'air'
   - pyarrow>=9.0.0 ; extra == 'air'
-  - virtualenv!=20.21.1,>=20.0.24 ; extra == 'air'
+  - virtualenv>=20.0.24,!=20.21.1 ; extra == 'air'
   - aiohttp-cors ; extra == 'air'
   - smart-open ; extra == 'air'
   - tensorboardx>=1.9 ; extra == 'air'
@@ -3942,7 +2876,7 @@ packages:
   - gymnasium==1.0.0 ; extra == 'all'
   - pyarrow>=9.0.0 ; extra == 'all'
   - opentelemetry-sdk ; extra == 'all'
-  - virtualenv!=20.21.1,>=20.0.24 ; extra == 'all'
+  - virtualenv>=20.0.24,!=20.21.1 ; extra == 'all'
   - typer ; extra == 'all'
   - aiohttp-cors ; extra == 'all'
   - smart-open ; extra == 'all'
@@ -3976,7 +2910,7 @@ packages:
   - gymnasium==1.0.0 ; extra == 'all-cpp'
   - pyarrow>=9.0.0 ; extra == 'all-cpp'
   - opentelemetry-sdk ; extra == 'all-cpp'
-  - virtualenv!=20.21.1,>=20.0.24 ; extra == 'all-cpp'
+  - virtualenv>=20.0.24,!=20.21.1 ; extra == 'all-cpp'
   - typer ; extra == 'all-cpp'
   - aiohttp-cors ; extra == 'all-cpp'
   - smart-open ; extra == 'all-cpp'
@@ -4021,7 +2955,7 @@ packages:
   - pydantic!=2.0.*,!=2.1.*,!=2.2.*,!=2.3.*,!=2.4.*,<3 ; extra == 'default'
   - prometheus-client>=0.7.1 ; extra == 'default'
   - smart-open ; extra == 'default'
-  - virtualenv!=20.21.1,>=20.0.24 ; extra == 'default'
+  - virtualenv>=20.0.24,!=20.21.1 ; extra == 'default'
   - grpcio>=1.32.0 ; python_full_version < '3.10' and extra == 'default'
   - grpcio>=1.42.0 ; python_full_version >= '3.10' and extra == 'default'
   - memray ; sys_platform != 'win32' and extra == 'default'
@@ -4048,7 +2982,7 @@ packages:
   - watchfiles ; extra == 'serve'
   - fastapi ; extra == 'serve'
   - colorful ; extra == 'serve'
-  - virtualenv!=20.21.1,>=20.0.24 ; extra == 'serve'
+  - virtualenv>=20.0.24,!=20.21.1 ; extra == 'serve'
   - pydantic!=2.0.*,!=2.1.*,!=2.2.*,!=2.3.*,!=2.4.*,<3 ; extra == 'serve'
   - aiohttp>=3.7 ; extra == 'serve'
   - py-spy>=0.2.0 ; extra == 'serve'
@@ -4062,7 +2996,7 @@ packages:
   - watchfiles ; extra == 'serve-grpc'
   - fastapi ; extra == 'serve-grpc'
   - colorful ; extra == 'serve-grpc'
-  - virtualenv!=20.21.1,>=20.0.24 ; extra == 'serve-grpc'
+  - virtualenv>=20.0.24,!=20.21.1 ; extra == 'serve-grpc'
   - pyopenssl ; extra == 'serve-grpc'
   - pydantic!=2.0.*,!=2.1.*,!=2.2.*,!=2.3.*,!=2.4.*,<3 ; extra == 'serve-grpc'
   - aiohttp>=3.7 ; extra == 'serve-grpc'
@@ -4090,13 +3024,7 @@ packages:
   - fsspec ; extra == 'tune'
   - pyarrow<18 ; platform_machine == 'x86_64' and sys_platform == 'darwin' and extra == 'tune'
   requires_python: '>=3.9'
-- kind: conda
-  name: readline
-  version: '8.2'
-  build: h8228510_1
-  build_number: 1
-  subdir: linux-64
-  url: https://conda.anaconda.org/conda-forge/linux-64/readline-8.2-h8228510_1.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-64/readline-8.2-h8228510_1.conda
   sha256: 5435cf39d039387fbdc977b0a762357ea909a7694d9528ab40f005e9208744d7
   md5: 47d31b792659ce70f470b5c82fdfb7a4
   depends:
@@ -4107,13 +3035,7 @@ packages:
   purls: []
   size: 281456
   timestamp: 1679532220005
-- kind: conda
-  name: readme_renderer
-  version: '44.0'
-  build: pyhd8ed1ab_0
-  subdir: noarch
-  noarch: python
-  url: https://conda.anaconda.org/conda-forge/noarch/readme_renderer-44.0-pyhd8ed1ab_0.conda
+- conda: https://conda.anaconda.org/conda-forge/noarch/readme_renderer-44.0-pyhd8ed1ab_0.conda
   sha256: 0e6fdf0b30448ca92a0767e982182154d531391856296feda983053c41cdac6f
   md5: 63260acf67cb6169bdf519405b96ee63
   depends:
@@ -4128,23 +3050,15 @@ packages:
   - pkg:pypi/readme-renderer?source=hash-mapping
   size: 17186
   timestamp: 1720528649611
-- kind: pypi
+- pypi: https://files.pythonhosted.org/packages/b7/59/2056f61236782a2c86b33906c025d4f4a0b17be0161b63b70fd9e8775d36/referencing-0.35.1-py3-none-any.whl
   name: referencing
   version: 0.35.1
-  url: https://files.pythonhosted.org/packages/b7/59/2056f61236782a2c86b33906c025d4f4a0b17be0161b63b70fd9e8775d36/referencing-0.35.1-py3-none-any.whl
   sha256: eda6d3234d62814d1c64e305c1331c9a3a6132da475ab6382eaa997b21ee75de
   requires_dist:
   - attrs>=22.2.0
   - rpds-py>=0.7.0
   requires_python: '>=3.8'
-- kind: conda
-  name: referencing
-  version: 0.35.1
-  build: pyhd8ed1ab_1
-  build_number: 1
-  subdir: noarch
-  noarch: python
-  url: https://conda.anaconda.org/conda-forge/noarch/referencing-0.35.1-pyhd8ed1ab_1.conda
+- conda: https://conda.anaconda.org/conda-forge/noarch/referencing-0.35.1-pyhd8ed1ab_1.conda
   sha256: f972eecb4dc8e06257af37642f92b0f2df04a7fe4c950f2e1045505e5e93985f
   md5: 8c9083612c1bfe6878715ed5732605f8
   depends:
@@ -4157,12 +3071,7 @@ packages:
   - pkg:pypi/referencing?source=hash-mapping
   size: 42201
   timestamp: 1733366868091
-- kind: conda
-  name: regex
-  version: 2024.11.6
-  build: py312h66e93f0_0
-  subdir: linux-64
-  url: https://conda.anaconda.org/conda-forge/linux-64/regex-2024.11.6-py312h66e93f0_0.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-64/regex-2024.11.6-py312h66e93f0_0.conda
   sha256: fcb5687d3ec5fff580b64b8fb649d9d65c999a91a5c3108a313ecdd2de99f06b
   md5: 647770db979b43f9c9ca25dcfa7dc4e4
   depends:
@@ -4176,27 +3085,19 @@ packages:
   - pkg:pypi/regex?source=hash-mapping
   size: 402821
   timestamp: 1730952378415
-- kind: pypi
+- pypi: https://files.pythonhosted.org/packages/f9/9b/335f9764261e915ed497fcdeb11df5dfd6f7bf257d4a6a2a686d80da4d54/requests-2.32.3-py3-none-any.whl
   name: requests
   version: 2.32.3
-  url: https://files.pythonhosted.org/packages/f9/9b/335f9764261e915ed497fcdeb11df5dfd6f7bf257d4a6a2a686d80da4d54/requests-2.32.3-py3-none-any.whl
   sha256: 70761cfe03c773ceb22aa2f671b4757976145175cdfca038c02654d061d6dcc6
   requires_dist:
-  - charset-normalizer<4,>=2
-  - idna<4,>=2.5
-  - urllib3<3,>=1.21.1
+  - charset-normalizer>=2,<4
+  - idna>=2.5,<4
+  - urllib3>=1.21.1,<3
   - certifi>=2017.4.17
-  - pysocks!=1.5.7,>=1.5.6 ; extra == 'socks'
-  - chardet<6,>=3.0.2 ; extra == 'use-chardet-on-py3'
+  - pysocks>=1.5.6,!=1.5.7 ; extra == 'socks'
+  - chardet>=3.0.2,<6 ; extra == 'use-chardet-on-py3'
   requires_python: '>=3.8'
-- kind: conda
-  name: requests
-  version: 2.32.3
-  build: pyhd8ed1ab_1
-  build_number: 1
-  subdir: noarch
-  noarch: python
-  url: https://conda.anaconda.org/conda-forge/noarch/requests-2.32.3-pyhd8ed1ab_1.conda
+- conda: https://conda.anaconda.org/conda-forge/noarch/requests-2.32.3-pyhd8ed1ab_1.conda
   sha256: d701ca1136197aa121bbbe0e8c18db6b5c94acbd041c2b43c70e5ae104e1d8ad
   md5: a9b9368f3701a417eac9edbcae7cb737
   depends:
@@ -4213,14 +3114,7 @@ packages:
   - pkg:pypi/requests?source=compressed-mapping
   size: 58723
   timestamp: 1733217126197
-- kind: conda
-  name: requests-toolbelt
-  version: 1.0.0
-  build: pyhd8ed1ab_1
-  build_number: 1
-  subdir: noarch
-  noarch: python
-  url: https://conda.anaconda.org/conda-forge/noarch/requests-toolbelt-1.0.0-pyhd8ed1ab_1.conda
+- conda: https://conda.anaconda.org/conda-forge/noarch/requests-toolbelt-1.0.0-pyhd8ed1ab_1.conda
   sha256: c0b815e72bb3f08b67d60d5e02251bbb0164905b5f72942ff5b6d2a339640630
   md5: 66de8645e324fda0ea6ef28c2f99a2ab
   depends:
@@ -4232,14 +3126,7 @@ packages:
   - pkg:pypi/requests-toolbelt?source=hash-mapping
   size: 44285
   timestamp: 1733734886897
-- kind: conda
-  name: rfc3986
-  version: 2.0.0
-  build: pyhd8ed1ab_1
-  build_number: 1
-  subdir: noarch
-  noarch: python
-  url: https://conda.anaconda.org/conda-forge/noarch/rfc3986-2.0.0-pyhd8ed1ab_1.conda
+- conda: https://conda.anaconda.org/conda-forge/noarch/rfc3986-2.0.0-pyhd8ed1ab_1.conda
   sha256: d617373ba1a5108336cb87754d030b9e384dcf91796d143fa60fe61e76e5cfb0
   md5: 43e14f832d7551e5a8910672bfc3d8c6
   depends:
@@ -4250,14 +3137,7 @@ packages:
   - pkg:pypi/rfc3986?source=hash-mapping
   size: 38028
   timestamp: 1733921806657
-- kind: conda
-  name: rich
-  version: 13.9.4
-  build: pyhd8ed1ab_1
-  build_number: 1
-  subdir: noarch
-  noarch: python
-  url: https://conda.anaconda.org/conda-forge/noarch/rich-13.9.4-pyhd8ed1ab_1.conda
+- conda: https://conda.anaconda.org/conda-forge/noarch/rich-13.9.4-pyhd8ed1ab_1.conda
   sha256: 06a760c5ae572e72e865d5a87e9fe3cc171e1a9c996e63daf3db52ff1a0b4457
   md5: 7aed65d4ff222bfb7335997aa40b7da5
   depends:
@@ -4271,13 +3151,7 @@ packages:
   - pkg:pypi/rich?source=compressed-mapping
   size: 185646
   timestamp: 1733342347277
-- kind: conda
-  name: rich-click
-  version: 1.8.3
-  build: pyhd8ed1ab_0
-  subdir: noarch
-  noarch: python
-  url: https://conda.anaconda.org/conda-forge/noarch/rich-click-1.8.3-pyhd8ed1ab_0.conda
+- conda: https://conda.anaconda.org/conda-forge/noarch/rich-click-1.8.3-pyhd8ed1ab_0.conda
   sha256: e83ebdc82e5787cb2dacd4380e0ca7c1ce4e7f356a0be0ccbac2ebcff1032efa
   md5: ad6cdc745c76535e7cc56aab865b1fc5
   depends:
@@ -4290,18 +3164,12 @@ packages:
   - pkg:pypi/rich-click?source=hash-mapping
   size: 33837
   timestamp: 1718026216838
-- kind: pypi
+- pypi: https://files.pythonhosted.org/packages/82/a1/a45f3e30835b553379b3a56ea6c4eb622cf11e72008229af840e4596a8ea/rpds_py-0.22.3-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.whl
   name: rpds-py
   version: 0.22.3
-  url: https://files.pythonhosted.org/packages/82/a1/a45f3e30835b553379b3a56ea6c4eb622cf11e72008229af840e4596a8ea/rpds_py-0.22.3-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.whl
   sha256: e67ba3c290821343c192f7eae1d8fd5999ca2dc99994114643e2f2d3e6138b15
   requires_python: '>=3.9'
-- kind: conda
-  name: rpds-py
-  version: 0.22.3
-  build: py312h12e396e_0
-  subdir: linux-64
-  url: https://conda.anaconda.org/conda-forge/linux-64/rpds-py-0.22.3-py312h12e396e_0.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-64/rpds-py-0.22.3-py312h12e396e_0.conda
   sha256: e8662d21ca3c912ac8941725392b838a29458b106ef22d9489cdf0f8de145fad
   md5: bfb49da0cc9098597d527def04d66f8b
   depends:
@@ -4317,12 +3185,7 @@ packages:
   - pkg:pypi/rpds-py?source=hash-mapping
   size: 354410
   timestamp: 1733366814237
-- kind: conda
-  name: ruff
-  version: 0.7.4
-  build: py312h2156523_0
-  subdir: linux-64
-  url: https://conda.anaconda.org/conda-forge/linux-64/ruff-0.7.4-py312h2156523_0.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-64/ruff-0.7.4-py312h2156523_0.conda
   sha256: 41424ae6a027f433d259aa384b29fa2fb8e366f5080e93179c1d228ba8e6bd83
   md5: 025594b21ff040de6d98e6b1ef699185
   depends:
@@ -4339,12 +3202,7 @@ packages:
   - pkg:pypi/ruff?source=hash-mapping
   size: 7788530
   timestamp: 1731708419964
-- kind: conda
-  name: scalene
-  version: 1.5.41
-  build: py312h7070661_0
-  subdir: linux-64
-  url: https://conda.anaconda.org/conda-forge/linux-64/scalene-1.5.41-py312h7070661_0.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-64/scalene-1.5.41-py312h7070661_0.conda
   sha256: 5c8069fc7f19bf124cf706426c92e7c11f3ce609b275832dda17b792c7e70fbe
   md5: 7fcd3f4ae7b8be9632acda161fcb3910
   depends:
@@ -4364,13 +3222,7 @@ packages:
   - pkg:pypi/scalene?source=hash-mapping
   size: 576545
   timestamp: 1714760304745
-- kind: conda
-  name: scipy
-  version: 1.14.1
-  build: py312h62794b6_2
-  build_number: 2
-  subdir: linux-64
-  url: https://conda.anaconda.org/conda-forge/linux-64/scipy-1.14.1-py312h62794b6_2.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-64/scipy-1.14.1-py312h62794b6_2.conda
   sha256: 6e4916d610dc15f9b504517bd6c1f3dbbae019a3c7abf0aeb55f310c452a4474
   md5: 94688dd449f6c092e5f951780235aca1
   depends:
@@ -4393,13 +3245,7 @@ packages:
   - pkg:pypi/scipy?source=hash-mapping
   size: 17444442
   timestamp: 1733621582568
-- kind: conda
-  name: secretstorage
-  version: 3.3.3
-  build: py312h7900ff3_3
-  build_number: 3
-  subdir: linux-64
-  url: https://conda.anaconda.org/conda-forge/linux-64/secretstorage-3.3.3-py312h7900ff3_3.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-64/secretstorage-3.3.3-py312h7900ff3_3.conda
   sha256: c6d5d0bc7fb6cbfa3b8be8f2399a3c1308b3392a4e20bd1a0f29a828fda5ab20
   md5: 4840da9db2808db946a0d979603c6de4
   depends:
@@ -4414,14 +3260,7 @@ packages:
   - pkg:pypi/secretstorage?source=hash-mapping
   size: 31601
   timestamp: 1725915741329
-- kind: conda
-  name: setuptools
-  version: 75.6.0
-  build: pyhff2d567_1
-  build_number: 1
-  subdir: noarch
-  noarch: python
-  url: https://conda.anaconda.org/conda-forge/noarch/setuptools-75.6.0-pyhff2d567_1.conda
+- conda: https://conda.anaconda.org/conda-forge/noarch/setuptools-75.6.0-pyhff2d567_1.conda
   sha256: abb12e1dd515b13660aacb5d0fd43835bc2186cab472df25b7716cd65e095111
   md5: fc80f7995e396cbaeabd23cf46c413dc
   depends:
@@ -4432,13 +3271,7 @@ packages:
   - pkg:pypi/setuptools?source=hash-mapping
   size: 774252
   timestamp: 1732632769210
-- kind: conda
-  name: six
-  version: 1.17.0
-  build: pyhd8ed1ab_0
-  subdir: noarch
-  noarch: python
-  url: https://conda.anaconda.org/conda-forge/noarch/six-1.17.0-pyhd8ed1ab_0.conda
+- conda: https://conda.anaconda.org/conda-forge/noarch/six-1.17.0-pyhd8ed1ab_0.conda
   sha256: 41db0180680cc67c3fa76544ffd48d6a5679d96f4b71d7498a759e94edc9a2db
   md5: a451d576819089b0d672f18768be0f65
   depends:
@@ -4449,13 +3282,7 @@ packages:
   - pkg:pypi/six?source=hash-mapping
   size: 16385
   timestamp: 1733381032766
-- kind: conda
-  name: smmap
-  version: 5.0.0
-  build: pyhd8ed1ab_0
-  subdir: noarch
-  noarch: python
-  url: https://conda.anaconda.org/conda-forge/noarch/smmap-5.0.0-pyhd8ed1ab_0.tar.bz2
+- conda: https://conda.anaconda.org/conda-forge/noarch/smmap-5.0.0-pyhd8ed1ab_0.tar.bz2
   sha256: 23011cb3e064525bdb8787c75126a2e78d2344a72cd6773922006d1da1f2af16
   md5: 62f26a3d1387acee31322208f0cfa3e0
   depends:
@@ -4466,14 +3293,7 @@ packages:
   - pkg:pypi/smmap?source=hash-mapping
   size: 22483
   timestamp: 1634310465482
-- kind: conda
-  name: soupsieve
-  version: '2.5'
-  build: pyhd8ed1ab_1
-  build_number: 1
-  subdir: noarch
-  noarch: python
-  url: https://conda.anaconda.org/conda-forge/noarch/soupsieve-2.5-pyhd8ed1ab_1.conda
+- conda: https://conda.anaconda.org/conda-forge/noarch/soupsieve-2.5-pyhd8ed1ab_1.conda
   sha256: 54ae221033db8fbcd4998ccb07f3c3828b4d77e73b0c72b18c1d6a507059059c
   md5: 3f144b2c34f8cb5a9abd9ed23a39c561
   depends:
@@ -4484,14 +3304,7 @@ packages:
   - pkg:pypi/soupsieve?source=hash-mapping
   size: 36754
   timestamp: 1693929424267
-- kind: conda
-  name: stack_data
-  version: 0.6.3
-  build: pyhd8ed1ab_1
-  build_number: 1
-  subdir: noarch
-  noarch: python
-  url: https://conda.anaconda.org/conda-forge/noarch/stack_data-0.6.3-pyhd8ed1ab_1.conda
+- conda: https://conda.anaconda.org/conda-forge/noarch/stack_data-0.6.3-pyhd8ed1ab_1.conda
   sha256: 570da295d421661af487f1595045760526964f41471021056e993e73089e9c41
   md5: b1b505328da7a6b246787df4b5a49fbc
   depends:
@@ -4505,13 +3318,7 @@ packages:
   - pkg:pypi/stack-data?source=hash-mapping
   size: 26988
   timestamp: 1733569565672
-- kind: conda
-  name: super-collections
-  version: 0.5.3
-  build: pyhd8ed1ab_0
-  subdir: noarch
-  noarch: python
-  url: https://conda.anaconda.org/conda-forge/noarch/super-collections-0.5.3-pyhd8ed1ab_0.conda
+- conda: https://conda.anaconda.org/conda-forge/noarch/super-collections-0.5.3-pyhd8ed1ab_0.conda
   sha256: ef433a056158a088ed25f12eb1e1386cfe1253cc7dec5d3a23482f4cc057bf3e
   md5: 5201b5981937167b2ba3d38916f7f7d4
   depends:
@@ -4522,13 +3329,7 @@ packages:
   purls: []
   size: 6276
   timestamp: 1728985843294
-- kind: conda
-  name: super_collections
-  version: 0.5.3
-  build: pyhd8ed1ab_0
-  subdir: noarch
-  noarch: python
-  url: https://conda.anaconda.org/conda-forge/noarch/super_collections-0.5.3-pyhd8ed1ab_0.conda
+- conda: https://conda.anaconda.org/conda-forge/noarch/super_collections-0.5.3-pyhd8ed1ab_0.conda
   sha256: a4b2fbdf92141a7ab3b39f1ab32a08d359594f664b733610f5fb1430f4b5df27
   md5: 5919642f54976cffce4676b574cc770e
   depends:
@@ -4540,14 +3341,7 @@ packages:
   - pkg:pypi/super-collections?source=hash-mapping
   size: 13584
   timestamp: 1728985831941
-- kind: conda
-  name: tabulate
-  version: 0.9.0
-  build: pyhd8ed1ab_2
-  build_number: 2
-  subdir: noarch
-  noarch: python
-  url: https://conda.anaconda.org/conda-forge/noarch/tabulate-0.9.0-pyhd8ed1ab_2.conda
+- conda: https://conda.anaconda.org/conda-forge/noarch/tabulate-0.9.0-pyhd8ed1ab_2.conda
   sha256: 090023bddd40d83468ef86573976af8c514f64119b2bd814ee63a838a542720a
   md5: 959484a66b4b76befcddc4fa97c95567
   depends:
@@ -4558,14 +3352,7 @@ packages:
   - pkg:pypi/tabulate?source=hash-mapping
   size: 37554
   timestamp: 1733589854804
-- kind: conda
-  name: termcolor
-  version: 2.5.0
-  build: pyhd8ed1ab_1
-  build_number: 1
-  subdir: noarch
-  noarch: python
-  url: https://conda.anaconda.org/conda-forge/noarch/termcolor-2.5.0-pyhd8ed1ab_1.conda
+- conda: https://conda.anaconda.org/conda-forge/noarch/termcolor-2.5.0-pyhd8ed1ab_1.conda
   sha256: 4a7e13776ebd78afcdba3985ea42317e4e0a20722d2c27ecaae3d9f8849e6516
   md5: 1ce02d60767af357e864ce61895268d2
   depends:
@@ -4576,13 +3363,7 @@ packages:
   - pkg:pypi/termcolor?source=hash-mapping
   size: 12665
   timestamp: 1733754731291
-- kind: conda
-  name: tinycss2
-  version: 1.4.0
-  build: pyhd8ed1ab_0
-  subdir: noarch
-  noarch: python
-  url: https://conda.anaconda.org/conda-forge/noarch/tinycss2-1.4.0-pyhd8ed1ab_0.conda
+- conda: https://conda.anaconda.org/conda-forge/noarch/tinycss2-1.4.0-pyhd8ed1ab_0.conda
   sha256: cad582d6f978276522f84bd209a5ddac824742fe2d452af6acf900f8650a73a2
   md5: f1acf5fdefa8300de697982bcb1761c9
   depends:
@@ -4594,13 +3375,7 @@ packages:
   - pkg:pypi/tinycss2?source=hash-mapping
   size: 28285
   timestamp: 1729802975370
-- kind: conda
-  name: tk
-  version: 8.6.13
-  build: noxft_h4845f30_101
-  build_number: 101
-  subdir: linux-64
-  url: https://conda.anaconda.org/conda-forge/linux-64/tk-8.6.13-noxft_h4845f30_101.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-64/tk-8.6.13-noxft_h4845f30_101.conda
   sha256: e0569c9caa68bf476bead1bed3d79650bb080b532c64a4af7d8ca286c08dea4e
   md5: d453b98d9c83e71da0741bb0ff4d76bc
   depends:
@@ -4611,14 +3386,7 @@ packages:
   purls: []
   size: 3318875
   timestamp: 1699202167581
-- kind: conda
-  name: toml
-  version: 0.10.2
-  build: pyhd8ed1ab_1
-  build_number: 1
-  subdir: noarch
-  noarch: python
-  url: https://conda.anaconda.org/conda-forge/noarch/toml-0.10.2-pyhd8ed1ab_1.conda
+- conda: https://conda.anaconda.org/conda-forge/noarch/toml-0.10.2-pyhd8ed1ab_1.conda
   sha256: 34f3a83384ac3ac30aefd1309e69498d8a4aa0bf2d1f21c645f79b180e378938
   md5: b0dd904de08b7db706167240bf37b164
   depends:
@@ -4629,14 +3397,7 @@ packages:
   - pkg:pypi/toml?source=hash-mapping
   size: 22132
   timestamp: 1734091907682
-- kind: conda
-  name: tomli
-  version: 2.2.1
-  build: pyhd8ed1ab_1
-  build_number: 1
-  subdir: noarch
-  noarch: python
-  url: https://conda.anaconda.org/conda-forge/noarch/tomli-2.2.1-pyhd8ed1ab_1.conda
+- conda: https://conda.anaconda.org/conda-forge/noarch/tomli-2.2.1-pyhd8ed1ab_1.conda
   sha256: 18636339a79656962723077df9a56c0ac7b8a864329eb8f847ee3d38495b863e
   md5: ac944244f1fed2eb49bae07193ae8215
   depends:
@@ -4647,14 +3408,7 @@ packages:
   - pkg:pypi/tomli?source=hash-mapping
   size: 19167
   timestamp: 1733256819729
-- kind: conda
-  name: tomlkit
-  version: 0.13.2
-  build: pyha770c72_1
-  build_number: 1
-  subdir: noarch
-  noarch: python
-  url: https://conda.anaconda.org/conda-forge/noarch/tomlkit-0.13.2-pyha770c72_1.conda
+- conda: https://conda.anaconda.org/conda-forge/noarch/tomlkit-0.13.2-pyha770c72_1.conda
   sha256: 986fae65f5568e95dbf858d08d77a0f9cca031345a98550f1d4b51d36d8811e2
   md5: 1d9ab4fc875c52db83f9c9b40af4e2c8
   depends:
@@ -4665,12 +3419,7 @@ packages:
   - pkg:pypi/tomlkit?source=hash-mapping
   size: 37372
   timestamp: 1733230836889
-- kind: conda
-  name: tornado
-  version: 6.4.2
-  build: py312h66e93f0_0
-  subdir: linux-64
-  url: https://conda.anaconda.org/conda-forge/linux-64/tornado-6.4.2-py312h66e93f0_0.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-64/tornado-6.4.2-py312h66e93f0_0.conda
   sha256: 062a3a3a37fa8615ce57929ba7e982c76f5a5810bcebd435950f6d6c4147c310
   md5: e417822cb989e80a0d2b1b576fdd1657
   depends:
@@ -4684,14 +3433,7 @@ packages:
   - pkg:pypi/tornado?source=compressed-mapping
   size: 840414
   timestamp: 1732616043734
-- kind: conda
-  name: traitlets
-  version: 5.14.3
-  build: pyhd8ed1ab_1
-  build_number: 1
-  subdir: noarch
-  noarch: python
-  url: https://conda.anaconda.org/conda-forge/noarch/traitlets-5.14.3-pyhd8ed1ab_1.conda
+- conda: https://conda.anaconda.org/conda-forge/noarch/traitlets-5.14.3-pyhd8ed1ab_1.conda
   sha256: f39a5620c6e8e9e98357507262a7869de2ae8cc07da8b7f84e517c9fd6c2b959
   md5: 019a7385be9af33791c989871317e1ed
   depends:
@@ -4702,13 +3444,7 @@ packages:
   - pkg:pypi/traitlets?source=hash-mapping
   size: 110051
   timestamp: 1733367480074
-- kind: conda
-  name: twine
-  version: 5.1.1
-  build: pyhd8ed1ab_0
-  subdir: noarch
-  noarch: python
-  url: https://conda.anaconda.org/conda-forge/noarch/twine-5.1.1-pyhd8ed1ab_0.conda
+- conda: https://conda.anaconda.org/conda-forge/noarch/twine-5.1.1-pyhd8ed1ab_0.conda
   sha256: e54a95bbc254e1196ebb4cb65b5653292e5ff83f924215bbe4a28c437e04754d
   md5: 5463141e576b9aaa0db7ed488e298241
   depends:
@@ -4728,14 +3464,7 @@ packages:
   - pkg:pypi/twine?source=hash-mapping
   size: 33938
   timestamp: 1719431080574
-- kind: conda
-  name: types-pyyaml
-  version: 6.0.12.20240917
-  build: pyhd8ed1ab_1
-  build_number: 1
-  subdir: noarch
-  noarch: python
-  url: https://conda.anaconda.org/conda-forge/noarch/types-pyyaml-6.0.12.20240917-pyhd8ed1ab_1.conda
+- conda: https://conda.anaconda.org/conda-forge/noarch/types-pyyaml-6.0.12.20240917-pyhd8ed1ab_1.conda
   sha256: ab1d358925af426bb0a2234e2803d8e425ce7dbb09e72f4005b6d674aa37e0ad
   md5: c823c98ead56f35b90cf891016bde9cc
   depends:
@@ -4745,14 +3474,8 @@ packages:
   - pkg:pypi/types-pyyaml?source=hash-mapping
   size: 21297
   timestamp: 1733260537257
-- kind: conda
-  name: typing-extensions
-  version: 4.12.2
-  build: hd8ed1ab_1
-  build_number: 1
-  subdir: noarch
+- conda: https://conda.anaconda.org/conda-forge/noarch/typing-extensions-4.12.2-hd8ed1ab_1.conda
   noarch: python
-  url: https://conda.anaconda.org/conda-forge/noarch/typing-extensions-4.12.2-hd8ed1ab_1.conda
   sha256: c8e9c1c467b5f960b627d7adc1c65fece8e929a3de89967e91ef0f726422fd32
   md5: b6a408c64b78ec7b779a3e5c7a902433
   depends:
@@ -4762,14 +3485,7 @@ packages:
   purls: []
   size: 10075
   timestamp: 1733188758872
-- kind: conda
-  name: typing_extensions
-  version: 4.12.2
-  build: pyha770c72_1
-  build_number: 1
-  subdir: noarch
-  noarch: python
-  url: https://conda.anaconda.org/conda-forge/noarch/typing_extensions-4.12.2-pyha770c72_1.conda
+- conda: https://conda.anaconda.org/conda-forge/noarch/typing_extensions-4.12.2-pyha770c72_1.conda
   sha256: 337be7af5af8b2817f115b3b68870208b30c31d3439bec07bfb2d8f4823e3568
   md5: d17f13df8b65464ca316cbc000a3cb64
   depends:
@@ -4780,39 +3496,25 @@ packages:
   - pkg:pypi/typing-extensions?source=compressed-mapping
   size: 39637
   timestamp: 1733188758212
-- kind: conda
-  name: tzdata
-  version: 2024b
-  build: hc8b5060_0
-  subdir: noarch
-  noarch: generic
-  url: https://conda.anaconda.org/conda-forge/noarch/tzdata-2024b-hc8b5060_0.conda
+- conda: https://conda.anaconda.org/conda-forge/noarch/tzdata-2024b-hc8b5060_0.conda
   sha256: 4fde5c3008bf5d2db82f2b50204464314cc3c91c1d953652f7bd01d9e52aefdf
   md5: 8ac3367aafb1cc0a068483c580af8015
   license: LicenseRef-Public-Domain
   purls: []
   size: 122354
   timestamp: 1728047496079
-- kind: pypi
+- pypi: https://files.pythonhosted.org/packages/ce/d9/5f4c13cecde62396b0d3fe530a50ccea91e7dfc1ccf0e09c228841bb5ba8/urllib3-2.2.3-py3-none-any.whl
   name: urllib3
   version: 2.2.3
-  url: https://files.pythonhosted.org/packages/ce/d9/5f4c13cecde62396b0d3fe530a50ccea91e7dfc1ccf0e09c228841bb5ba8/urllib3-2.2.3-py3-none-any.whl
   sha256: ca899ca043dcb1bafa3e262d73aa25c465bfb49e0bd9dd5d59f1d0acba2f8fac
   requires_dist:
   - brotli>=1.0.9 ; platform_python_implementation == 'CPython' and extra == 'brotli'
   - brotlicffi>=0.8.0 ; platform_python_implementation != 'CPython' and extra == 'brotli'
-  - h2<5,>=4 ; extra == 'h2'
-  - pysocks!=1.5.7,<2.0,>=1.5.6 ; extra == 'socks'
+  - h2>=4,<5 ; extra == 'h2'
+  - pysocks>=1.5.6,!=1.5.7,<2.0 ; extra == 'socks'
   - zstandard>=0.18.0 ; extra == 'zstd'
   requires_python: '>=3.8'
-- kind: conda
-  name: urllib3
-  version: 2.2.3
-  build: pyhd8ed1ab_1
-  build_number: 1
-  subdir: noarch
-  noarch: python
-  url: https://conda.anaconda.org/conda-forge/noarch/urllib3-2.2.3-pyhd8ed1ab_1.conda
+- conda: https://conda.anaconda.org/conda-forge/noarch/urllib3-2.2.3-pyhd8ed1ab_1.conda
   sha256: 416e30a1c3262275f01a3e22e783118d9e9d2872a739a9ed860d06fa9c7593d5
   md5: 4a2d8ef7c37b8808c5b9b750501fffce
   depends:
@@ -4827,12 +3529,7 @@ packages:
   - pkg:pypi/urllib3?source=hash-mapping
   size: 98077
   timestamp: 1733206968917
-- kind: conda
-  name: watchdog
-  version: 6.0.0
-  build: py312h7900ff3_0
-  subdir: linux-64
-  url: https://conda.anaconda.org/conda-forge/linux-64/watchdog-6.0.0-py312h7900ff3_0.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-64/watchdog-6.0.0-py312h7900ff3_0.conda
   sha256: 2436c4736b8135801f6bfcd09c7283f2d700a66a90ebd14b666b996e33ef8c9a
   md5: 687b37d1325f228429409465e811c0bc
   depends:
@@ -4845,21 +3542,14 @@ packages:
   - pkg:pypi/watchdog?source=hash-mapping
   size: 140940
   timestamp: 1730493008472
-- kind: pypi
+- pypi: https://files.pythonhosted.org/packages/ab/df/4ee467ab39cc1de4b852c212c1ed3becfec2e486a51ac1ce0091f85f38d7/wcmatch-10.0-py3-none-any.whl
   name: wcmatch
   version: '10.0'
-  url: https://files.pythonhosted.org/packages/ab/df/4ee467ab39cc1de4b852c212c1ed3becfec2e486a51ac1ce0091f85f38d7/wcmatch-10.0-py3-none-any.whl
   sha256: 0dd927072d03c0a6527a20d2e6ad5ba8d0380e60870c383bc533b71744df7b7a
   requires_dist:
   - bracex>=2.1.1
   requires_python: '>=3.8'
-- kind: conda
-  name: wcmatch
-  version: '10.0'
-  build: pyhd8ed1ab_0
-  subdir: noarch
-  noarch: python
-  url: https://conda.anaconda.org/conda-forge/noarch/wcmatch-10.0-pyhd8ed1ab_0.conda
+- conda: https://conda.anaconda.org/conda-forge/noarch/wcmatch-10.0-pyhd8ed1ab_0.conda
   sha256: 9883e1a7c65f91c3480b38137af5b1d88ee38150b1943c356d11f6b0cd374a8b
   md5: b262b976f96f01ad6847b20dbea512af
   depends:
@@ -4871,14 +3561,7 @@ packages:
   - pkg:pypi/wcmatch?source=hash-mapping
   size: 37788
   timestamp: 1727447886965
-- kind: conda
-  name: wcwidth
-  version: 0.2.13
-  build: pyhd8ed1ab_1
-  build_number: 1
-  subdir: noarch
-  noarch: python
-  url: https://conda.anaconda.org/conda-forge/noarch/wcwidth-0.2.13-pyhd8ed1ab_1.conda
+- conda: https://conda.anaconda.org/conda-forge/noarch/wcwidth-0.2.13-pyhd8ed1ab_1.conda
   sha256: f21e63e8f7346f9074fd00ca3b079bd3d2fa4d71f1f89d5b6934bf31446dc2a5
   md5: b68980f2495d096e71c7fd9d7ccf63e6
   depends:
@@ -4889,14 +3572,7 @@ packages:
   - pkg:pypi/wcwidth?source=hash-mapping
   size: 32581
   timestamp: 1733231433877
-- kind: conda
-  name: webencodings
-  version: 0.5.1
-  build: pyhd8ed1ab_3
-  build_number: 3
-  subdir: noarch
-  noarch: python
-  url: https://conda.anaconda.org/conda-forge/noarch/webencodings-0.5.1-pyhd8ed1ab_3.conda
+- conda: https://conda.anaconda.org/conda-forge/noarch/webencodings-0.5.1-pyhd8ed1ab_3.conda
   sha256: 19ff205e138bb056a46f9e3839935a2e60bd1cf01c8241a5e172a422fed4f9c6
   md5: 2841eb5bfc75ce15e9a0054b98dcd64d
   depends:
@@ -4907,14 +3583,7 @@ packages:
   - pkg:pypi/webencodings?source=hash-mapping
   size: 15496
   timestamp: 1733236131358
-- kind: conda
-  name: wheel
-  version: 0.45.1
-  build: pyhd8ed1ab_1
-  build_number: 1
-  subdir: noarch
-  noarch: python
-  url: https://conda.anaconda.org/conda-forge/noarch/wheel-0.45.1-pyhd8ed1ab_1.conda
+- conda: https://conda.anaconda.org/conda-forge/noarch/wheel-0.45.1-pyhd8ed1ab_1.conda
   sha256: 1b34021e815ff89a4d902d879c3bd2040bc1bd6169b32e9427497fa05c55f1ce
   md5: 75cb7132eb58d97896e173ef12ac9986
   depends:
@@ -4925,13 +3594,7 @@ packages:
   - pkg:pypi/wheel?source=compressed-mapping
   size: 62931
   timestamp: 1733130309598
-- kind: conda
-  name: yaml
-  version: 0.2.5
-  build: h7f98852_2
-  build_number: 2
-  subdir: linux-64
-  url: https://conda.anaconda.org/conda-forge/linux-64/yaml-0.2.5-h7f98852_2.tar.bz2
+- conda: https://conda.anaconda.org/conda-forge/linux-64/yaml-0.2.5-h7f98852_2.tar.bz2
   sha256: a4e34c710eeb26945bdbdaba82d3d74f60a78f54a874ec10d373811a5d217535
   md5: 4cb3ad778ec2d5a7acbdf254eb1c42ae
   depends:
@@ -4941,13 +3604,7 @@ packages:
   purls: []
   size: 89141
   timestamp: 1641346969816
-- kind: conda
-  name: zeromq
-  version: 4.3.5
-  build: h3b0a872_7
-  build_number: 7
-  subdir: linux-64
-  url: https://conda.anaconda.org/conda-forge/linux-64/zeromq-4.3.5-h3b0a872_7.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-64/zeromq-4.3.5-h3b0a872_7.conda
   sha256: a4dc72c96848f764bb5a5176aa93dd1e9b9e52804137b99daeebba277b31ea10
   md5: 3947a35e916fcc6b9825449affbf4214
   depends:
@@ -4961,14 +3618,7 @@ packages:
   purls: []
   size: 335400
   timestamp: 1731585026517
-- kind: conda
-  name: zipp
-  version: 3.21.0
-  build: pyhd8ed1ab_1
-  build_number: 1
-  subdir: noarch
-  noarch: python
-  url: https://conda.anaconda.org/conda-forge/noarch/zipp-3.21.0-pyhd8ed1ab_1.conda
+- conda: https://conda.anaconda.org/conda-forge/noarch/zipp-3.21.0-pyhd8ed1ab_1.conda
   sha256: 567c04f124525c97a096b65769834b7acb047db24b15a56888a322bf3966c3e1
   md5: 0c3cc595284c5e8f0f9900a9b228a332
   depends:
@@ -4979,13 +3629,7 @@ packages:
   - pkg:pypi/zipp?source=hash-mapping
   size: 21809
   timestamp: 1732827613585
-- kind: conda
-  name: zstandard
-  version: 0.23.0
-  build: py312hef9b889_1
-  build_number: 1
-  subdir: linux-64
-  url: https://conda.anaconda.org/conda-forge/linux-64/zstandard-0.23.0-py312hef9b889_1.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-64/zstandard-0.23.0-py312hef9b889_1.conda
   sha256: b97015e146437283f2213ff0e95abdc8e2480150634d81fbae6b96ee09f5e50b
   md5: 8b7069e9792ee4e5b4919a7a306d2e67
   depends:
@@ -5002,12 +3646,7 @@ packages:
   - pkg:pypi/zstandard?source=hash-mapping
   size: 419552
   timestamp: 1725305670210
-- kind: conda
-  name: zstd
-  version: 1.5.6
-  build: ha6fb4c9_0
-  subdir: linux-64
-  url: https://conda.anaconda.org/conda-forge/linux-64/zstd-1.5.6-ha6fb4c9_0.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-64/zstd-1.5.6-ha6fb4c9_0.conda
   sha256: c558b9cc01d9c1444031bd1ce4b9cff86f9085765f17627a6cd85fc623c8a02b
   md5: 4d056880988120e29d75bfff282e0f45
   depends:

--- a/pixi.toml
+++ b/pixi.toml
@@ -9,7 +9,7 @@ readme = "README.md"
 
 [pypi-dependencies]
 povme = { path = ".", editable = true }
-pymolecule = { git = "https://github.com/durrantlab/pymolecule.git", rev = "121c34103169d362f4ed2ca9207dd5555f9dc25b" }
+pymolecule = { git = "https://github.com/durrantlab/pymolecule.git", rev = "423cf64f17c21881a1685402437bd69a81e79ccf" }
 ray = { version = ">=2.37.0,<3"}
 
 [system-requirements]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,13 +1,15 @@
 [project]
+name = "povme"
+version = "2.2.1"
+description = "Detect and characterize protein pockets."
 authors = [
     {name = "Durrant Lab", email = "durrantj@pitt.edu"}
 ]
 maintainers = [
-    {name = "Jacob Durrant", email = "durrantj@pitt.edu"}
+    {name = "Jacob Durrant", email = "durrantj@pitt.edu"},
+    {name = "Alex Maldonado", email = "alex.maldonado@pitt.edu"},
 ]
-description = "TODO"
-name = "povme"
-version = "2.2.1"
+license = "Apache-2.0"
 readme = "README.md"
 requires-python = ">=3.10,<3.13"
 # TODO: Keep this here until pixi releases building capabilities
@@ -18,13 +20,20 @@ dependencies = [
     "pyyaml>=6.0.2,<7",
     "loguru>=0.7.2,<0.8",
     "ray>=2.38.0,<3",
+    "pymolecule@git+https://github.com/durrantlab/pymolecule",
 ]
+
+[project.urls]
+Repository = "https://github.com/durrantlab/POVME"
+Documentation = "https://durrantlab.github.io/POVME/"
+Homepage = "https://durrantlab.github.io/POVME/"
 
 [project.scripts]
 povme = "povme.cli:povme_cli"
 
 [build-system]
-requires = ["setuptools"]
+requires = ["setuptools", "wheel"]
+build-backend = "setuptools.build_meta"
 
 [tool.setuptools.packages.find]
 where = ["."]

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -55,6 +55,16 @@ def path_rel1_output():
 
 
 @pytest.fixture
+def path_5csn_config():
+    return os.path.join(TEST_DIR, "files/5csn/pocket-id.yml")
+
+
+@pytest.fixture
+def path_5csn_output():
+    return os.path.join(TEST_DIR, "tmp/", "5csn/")
+
+
+@pytest.fixture
 def path_rogfp2_pdb():
     return os.path.join(TEST_DIR, "files/rogfp2/rogfp2.pdb")
 

--- a/tests/files/5csn/5csn.pdb
+++ b/tests/files/5csn/5csn.pdb
@@ -1,0 +1,2088 @@
+HEADER    TRANSFERASE                             23-JUL-15   5CSN              
+TITLE     S100B-RSK1 CRYSTAL STRUCTURE C                                        
+COMPND    MOL_ID: 1;                                                            
+COMPND   2 MOLECULE: PROTEIN S100-B;                                            
+COMPND   3 CHAIN: A, B;                                                         
+COMPND   4 SYNONYM: S-100 PROTEIN BETA CHAIN,S-100 PROTEIN SUBUNIT BETA,S100    
+COMPND   5 CALCIUM-BINDING PROTEIN B;                                           
+COMPND   6 ENGINEERED: YES;                                                     
+COMPND   7 MOL_ID: 2;                                                           
+COMPND   8 MOLECULE: RIBOSOMAL PROTEIN S6 KINASE ALPHA-1;                       
+COMPND   9 CHAIN: C;                                                            
+COMPND  10 FRAGMENT: UNP RESIDUES 683-720;                                      
+COMPND  11 SYNONYM: S6K-ALPHA-1,90 KDA RIBOSOMAL PROTEIN S6 KINASE 1,P90S6K,MAP 
+COMPND  12 KINASE-ACTIVATED PROTEIN KINASE 1A,MAPKAPK-1A,RIBOSOMAL S6 KINASE 1, 
+COMPND  13 RSK-1;                                                               
+COMPND  14 EC: 2.7.11.1;                                                        
+COMPND  15 ENGINEERED: YES                                                      
+SOURCE    MOL_ID: 1;                                                            
+SOURCE   2 ORGANISM_SCIENTIFIC: HOMO SAPIENS;                                   
+SOURCE   3 ORGANISM_COMMON: HUMAN;                                              
+SOURCE   4 ORGANISM_TAXID: 9606;                                                
+SOURCE   5 GENE: S100B;                                                         
+SOURCE   6 EXPRESSION_SYSTEM: ESCHERICHIA COLI;                                 
+SOURCE   7 EXPRESSION_SYSTEM_TAXID: 562;                                        
+SOURCE   8 MOL_ID: 2;                                                           
+SOURCE   9 ORGANISM_SCIENTIFIC: HOMO SAPIENS;                                   
+SOURCE  10 ORGANISM_COMMON: HUMAN;                                              
+SOURCE  11 ORGANISM_TAXID: 9606;                                                
+SOURCE  12 GENE: RPS6KA1, MAPKAPK1A, RSK1;                                      
+SOURCE  13 EXPRESSION_SYSTEM: ESCHERICHIA COLI;                                 
+SOURCE  14 EXPRESSION_SYSTEM_TAXID: 562                                         
+KEYWDS    S100, KINASE, SIGNALING, INHIBITOR, TRANSFERASE                       
+EXPDTA    X-RAY DIFFRACTION                                                     
+AUTHOR    G.GOGL,L.NYITRAY                                                      
+REVDAT   4   10-JAN-24 5CSN    1       REMARK                                   
+REVDAT   3   13-JAN-16 5CSN    1       JRNL                                     
+REVDAT   2   18-NOV-15 5CSN    1       JRNL                                     
+REVDAT   1   11-NOV-15 5CSN    0                                                
+JRNL        AUTH   G.GOGL,A.ALEXA,B.KISS,G.KATONA,M.KOVACS,A.BODOR,A.REMENYI,   
+JRNL        AUTH 2 L.NYITRAY                                                    
+JRNL        TITL   STRUCTURAL BASIS OF RIBOSOMAL S6 KINASE 1 (RSK1) INHIBITION  
+JRNL        TITL 2 BY S100B PROTEIN: MODULATION OF THE EXTRACELLULAR            
+JRNL        TITL 3 SIGNAL-REGULATED KINASE (ERK) SIGNALING CASCADE IN A         
+JRNL        TITL 4 CALCIUM-DEPENDENT WAY.                                       
+JRNL        REF    J.BIOL.CHEM.                  V. 291    11 2016              
+JRNL        REFN                   ESSN 1083-351X                               
+JRNL        PMID   26527685                                                     
+JRNL        DOI    10.1074/JBC.M115.684928                                      
+REMARK   2                                                                      
+REMARK   2 RESOLUTION.    2.95 ANGSTROMS.                                       
+REMARK   3                                                                      
+REMARK   3 REFINEMENT.                                                          
+REMARK   3   PROGRAM     : PHENIX DEV_1750                                      
+REMARK   3   AUTHORS     : PAUL ADAMS,PAVEL AFONINE,VINCENT CHEN,IAN            
+REMARK   3               : DAVIS,KRESHNA GOPAL,RALF GROSSE-KUNSTLEVE,           
+REMARK   3               : LI-WEI HUNG,ROBERT IMMORMINO,TOM IOERGER,            
+REMARK   3               : AIRLIE MCCOY,ERIK MCKEE,NIGEL MORIARTY,              
+REMARK   3               : REETAL PAI,RANDY READ,JANE RICHARDSON,               
+REMARK   3               : DAVID RICHARDSON,TOD ROMO,JIM SACCHETTINI,           
+REMARK   3               : NICHOLAS SAUTER,JACOB SMITH,LAURENT                  
+REMARK   3               : STORONI,TOM TERWILLIGER,PETER ZWART                  
+REMARK   3                                                                      
+REMARK   3    REFINEMENT TARGET : ML                                            
+REMARK   3                                                                      
+REMARK   3  DATA USED IN REFINEMENT.                                            
+REMARK   3   RESOLUTION RANGE HIGH (ANGSTROMS) : 2.95                           
+REMARK   3   RESOLUTION RANGE LOW  (ANGSTROMS) : 44.59                          
+REMARK   3   MIN(FOBS/SIGMA_FOBS)              : 1.360                          
+REMARK   3   COMPLETENESS FOR RANGE        (%) : 100.0                          
+REMARK   3   NUMBER OF REFLECTIONS             : 6014                           
+REMARK   3                                                                      
+REMARK   3  FIT TO DATA USED IN REFINEMENT.                                     
+REMARK   3   R VALUE     (WORKING + TEST SET) : 0.253                           
+REMARK   3   R VALUE            (WORKING SET) : 0.251                           
+REMARK   3   FREE R VALUE                     : 0.279                           
+REMARK   3   FREE R VALUE TEST SET SIZE   (%) : 4.660                           
+REMARK   3   FREE R VALUE TEST SET COUNT      : 280                             
+REMARK   3                                                                      
+REMARK   3  FIT TO DATA USED IN REFINEMENT (IN BINS).                           
+REMARK   3   BIN  RESOLUTION RANGE  COMPL.    NWORK NFREE   RWORK  RFREE        
+REMARK   3     1 44.5901 -  3.7164    1.00     2940   137  0.2381 0.2521        
+REMARK   3     2  3.7164 -  2.9500    1.00     2794   143  0.2915 0.3516        
+REMARK   3                                                                      
+REMARK   3  BULK SOLVENT MODELLING.                                             
+REMARK   3   METHOD USED        : FLAT BULK SOLVENT MODEL                       
+REMARK   3   SOLVENT RADIUS     : 1.11                                          
+REMARK   3   SHRINKAGE RADIUS   : 0.90                                          
+REMARK   3   K_SOL              : NULL                                          
+REMARK   3   B_SOL              : NULL                                          
+REMARK   3                                                                      
+REMARK   3  ERROR ESTIMATES.                                                    
+REMARK   3   COORDINATE ERROR (MAXIMUM-LIKELIHOOD BASED)     : 0.430            
+REMARK   3   PHASE ERROR (DEGREES, MAXIMUM-LIKELIHOOD BASED) : 28.660           
+REMARK   3                                                                      
+REMARK   3  B VALUES.                                                           
+REMARK   3   FROM WILSON PLOT           (A**2) : NULL                           
+REMARK   3   MEAN B VALUE      (OVERALL, A**2) : NULL                           
+REMARK   3   OVERALL ANISOTROPIC B VALUE.                                       
+REMARK   3    B11 (A**2) : NULL                                                 
+REMARK   3    B22 (A**2) : NULL                                                 
+REMARK   3    B33 (A**2) : NULL                                                 
+REMARK   3    B12 (A**2) : NULL                                                 
+REMARK   3    B13 (A**2) : NULL                                                 
+REMARK   3    B23 (A**2) : NULL                                                 
+REMARK   3                                                                      
+REMARK   3  TWINNING INFORMATION.                                               
+REMARK   3   FRACTION: NULL                                                     
+REMARK   3   OPERATOR: NULL                                                     
+REMARK   3                                                                      
+REMARK   3  DEVIATIONS FROM IDEAL VALUES.                                       
+REMARK   3                 RMSD          COUNT                                  
+REMARK   3   BOND      :  0.011           1622                                  
+REMARK   3   ANGLE     :  0.849           2149                                  
+REMARK   3   CHIRALITY :  0.033            241                                  
+REMARK   3   PLANARITY :  0.003            283                                  
+REMARK   3   DIHEDRAL  : 15.005            570                                  
+REMARK   3                                                                      
+REMARK   3  TLS DETAILS                                                         
+REMARK   3   NUMBER OF TLS GROUPS  : NULL                                       
+REMARK   3                                                                      
+REMARK   3  NCS DETAILS                                                         
+REMARK   3   NUMBER OF NCS GROUPS : NULL                                        
+REMARK   3                                                                      
+REMARK   3  OTHER REFINEMENT REMARKS: NULL                                      
+REMARK   4                                                                      
+REMARK   4 5CSN COMPLIES WITH FORMAT V. 3.30, 13-JUL-11                         
+REMARK 100                                                                      
+REMARK 100 THIS ENTRY HAS BEEN PROCESSED BY PDBE ON 23-JUL-15.                  
+REMARK 100 THE DEPOSITION ID IS D_1000212122.                                   
+REMARK 200                                                                      
+REMARK 200 EXPERIMENTAL DETAILS                                                 
+REMARK 200  EXPERIMENT TYPE                : X-RAY DIFFRACTION                  
+REMARK 200  DATE OF DATA COLLECTION        : 21-JUN-15                          
+REMARK 200  TEMPERATURE           (KELVIN) : 100                                
+REMARK 200  PH                             : NULL                               
+REMARK 200  NUMBER OF CRYSTALS USED        : NULL                               
+REMARK 200                                                                      
+REMARK 200  SYNCHROTRON              (Y/N) : Y                                  
+REMARK 200  RADIATION SOURCE               : ESRF                               
+REMARK 200  BEAMLINE                       : ID29                               
+REMARK 200  X-RAY GENERATOR MODEL          : NULL                               
+REMARK 200  MONOCHROMATIC OR LAUE    (M/L) : M                                  
+REMARK 200  WAVELENGTH OR RANGE        (A) : 0.9677                             
+REMARK 200  MONOCHROMATOR                  : NULL                               
+REMARK 200  OPTICS                         : NULL                               
+REMARK 200                                                                      
+REMARK 200  DETECTOR TYPE                  : PIXEL                              
+REMARK 200  DETECTOR MANUFACTURER          : DECTRIS PILATUS 2M                 
+REMARK 200  INTENSITY-INTEGRATION SOFTWARE : XDS                                
+REMARK 200  DATA SCALING SOFTWARE          : XDS                                
+REMARK 200                                                                      
+REMARK 200  NUMBER OF UNIQUE REFLECTIONS   : 6056                               
+REMARK 200  RESOLUTION RANGE HIGH      (A) : 2.950                              
+REMARK 200  RESOLUTION RANGE LOW       (A) : 44.590                             
+REMARK 200  REJECTION CRITERIA  (SIGMA(I)) : NULL                               
+REMARK 200                                                                      
+REMARK 200 OVERALL.                                                             
+REMARK 200  COMPLETENESS FOR RANGE     (%) : 99.9                               
+REMARK 200  DATA REDUNDANCY                : 17.32                              
+REMARK 200  R MERGE                    (I) : NULL                               
+REMARK 200  R SYM                      (I) : 0.15500                            
+REMARK 200  <I/SIGMA(I)> FOR THE DATA SET  : 15.8500                            
+REMARK 200                                                                      
+REMARK 200 IN THE HIGHEST RESOLUTION SHELL.                                     
+REMARK 200  HIGHEST RESOLUTION SHELL, RANGE HIGH (A) : 2.95                     
+REMARK 200  HIGHEST RESOLUTION SHELL, RANGE LOW  (A) : 3.03                     
+REMARK 200  COMPLETENESS FOR SHELL     (%) : 100.0                              
+REMARK 200  DATA REDUNDANCY IN SHELL       : 17.81                              
+REMARK 200  R MERGE FOR SHELL          (I) : NULL                               
+REMARK 200  R SYM FOR SHELL            (I) : 2.12600                            
+REMARK 200  <I/SIGMA(I)> FOR SHELL         : 1.800                              
+REMARK 200                                                                      
+REMARK 200 DIFFRACTION PROTOCOL: SINGLE WAVELENGTH                              
+REMARK 200 METHOD USED TO DETERMINE THE STRUCTURE: MOLECULAR REPLACEMENT        
+REMARK 200 SOFTWARE USED: PHASER                                                
+REMARK 200 STARTING MODEL: 3CZT                                                 
+REMARK 200                                                                      
+REMARK 200 REMARK: NULL                                                         
+REMARK 280                                                                      
+REMARK 280 CRYSTAL                                                              
+REMARK 280 SOLVENT CONTENT, VS   (%): 50.76                                     
+REMARK 280 MATTHEWS COEFFICIENT, VM (ANGSTROMS**3/DA): 2.50                     
+REMARK 280                                                                      
+REMARK 280 CRYSTALLIZATION CONDITIONS: 0.1 M HEPES 7, 150 MM NACL, 20%          
+REMARK 280  PEG6000, VAPOR DIFFUSION, SITTING DROP, TEMPERATURE 296K            
+REMARK 290                                                                      
+REMARK 290 CRYSTALLOGRAPHIC SYMMETRY                                            
+REMARK 290 SYMMETRY OPERATORS FOR SPACE GROUP: P 21 21 21                       
+REMARK 290                                                                      
+REMARK 290      SYMOP   SYMMETRY                                                
+REMARK 290     NNNMMM   OPERATOR                                                
+REMARK 290       1555   X,Y,Z                                                   
+REMARK 290       2555   -X+1/2,-Y,Z+1/2                                         
+REMARK 290       3555   -X,Y+1/2,-Z+1/2                                         
+REMARK 290       4555   X+1/2,-Y+1/2,-Z                                         
+REMARK 290                                                                      
+REMARK 290     WHERE NNN -> OPERATOR NUMBER                                     
+REMARK 290           MMM -> TRANSLATION VECTOR                                  
+REMARK 290                                                                      
+REMARK 290 CRYSTALLOGRAPHIC SYMMETRY TRANSFORMATIONS                            
+REMARK 290 THE FOLLOWING TRANSFORMATIONS OPERATE ON THE ATOM/HETATM             
+REMARK 290 RECORDS IN THIS ENTRY TO PRODUCE CRYSTALLOGRAPHICALLY                
+REMARK 290 RELATED MOLECULES.                                                   
+REMARK 290   SMTRY1   1  1.000000  0.000000  0.000000        0.00000            
+REMARK 290   SMTRY2   1  0.000000  1.000000  0.000000        0.00000            
+REMARK 290   SMTRY3   1  0.000000  0.000000  1.000000        0.00000            
+REMARK 290   SMTRY1   2 -1.000000  0.000000  0.000000       18.39500            
+REMARK 290   SMTRY2   2  0.000000 -1.000000  0.000000        0.00000            
+REMARK 290   SMTRY3   2  0.000000  0.000000  1.000000       89.17000            
+REMARK 290   SMTRY1   3 -1.000000  0.000000  0.000000        0.00000            
+REMARK 290   SMTRY2   3  0.000000  1.000000  0.000000       19.96500            
+REMARK 290   SMTRY3   3  0.000000  0.000000 -1.000000       89.17000            
+REMARK 290   SMTRY1   4  1.000000  0.000000  0.000000       18.39500            
+REMARK 290   SMTRY2   4  0.000000 -1.000000  0.000000       19.96500            
+REMARK 290   SMTRY3   4  0.000000  0.000000 -1.000000        0.00000            
+REMARK 290                                                                      
+REMARK 290 REMARK: NULL                                                         
+REMARK 300                                                                      
+REMARK 300 BIOMOLECULE: 1                                                       
+REMARK 300 SEE REMARK 350 FOR THE AUTHOR PROVIDED AND/OR PROGRAM                
+REMARK 300 GENERATED ASSEMBLY INFORMATION FOR THE STRUCTURE IN                  
+REMARK 300 THIS ENTRY. THE REMARK MAY ALSO PROVIDE INFORMATION ON               
+REMARK 300 BURIED SURFACE AREA.                                                 
+REMARK 350                                                                      
+REMARK 350 COORDINATES FOR A COMPLETE MULTIMER REPRESENTING THE KNOWN           
+REMARK 350 BIOLOGICALLY SIGNIFICANT OLIGOMERIZATION STATE OF THE                
+REMARK 350 MOLECULE CAN BE GENERATED BY APPLYING BIOMT TRANSFORMATIONS          
+REMARK 350 GIVEN BELOW.  BOTH NON-CRYSTALLOGRAPHIC AND                          
+REMARK 350 CRYSTALLOGRAPHIC OPERATIONS ARE GIVEN.                               
+REMARK 350                                                                      
+REMARK 350 BIOMOLECULE: 1                                                       
+REMARK 350 AUTHOR DETERMINED BIOLOGICAL UNIT: TRIMERIC                          
+REMARK 350 SOFTWARE DETERMINED QUATERNARY STRUCTURE: TRIMERIC                   
+REMARK 350 SOFTWARE USED: PISA                                                  
+REMARK 350 TOTAL BURIED SURFACE AREA: 4600 ANGSTROM**2                          
+REMARK 350 SURFACE AREA OF THE COMPLEX: 10740 ANGSTROM**2                       
+REMARK 350 CHANGE IN SOLVENT FREE ENERGY: -67.0 KCAL/MOL                        
+REMARK 350 APPLY THE FOLLOWING TO CHAINS: A, B, C                               
+REMARK 350   BIOMT1   1  1.000000  0.000000  0.000000        0.00000            
+REMARK 350   BIOMT2   1  0.000000  1.000000  0.000000        0.00000            
+REMARK 350   BIOMT3   1  0.000000  0.000000  1.000000        0.00000            
+REMARK 465                                                                      
+REMARK 465 MISSING RESIDUES                                                     
+REMARK 465 THE FOLLOWING RESIDUES WERE NOT LOCATED IN THE                       
+REMARK 465 EXPERIMENT. (M=MODEL NUMBER; RES=RESIDUE NAME; C=CHAIN               
+REMARK 465 IDENTIFIER; SSSEQ=SEQUENCE NUMBER; I=INSERTION CODE.)                
+REMARK 465                                                                      
+REMARK 465   M RES C SSSEQI                                                     
+REMARK 465     GLU A    91                                                      
+REMARK 465     GLY B    -3                                                      
+REMARK 465     GLU B    89                                                      
+REMARK 465     HIS B    90                                                      
+REMARK 465     GLU B    91                                                      
+REMARK 465     GLY C   681                                                      
+REMARK 465     SER C   682                                                      
+REMARK 465     GLN C   683                                                      
+REMARK 465     SER C   684                                                      
+REMARK 465     GLN C   685                                                      
+REMARK 465     LEU C   686                                                      
+REMARK 465     SER C   687                                                      
+REMARK 465     HIS C   688                                                      
+REMARK 465     GLN C   689                                                      
+REMARK 465     ASP C   690                                                      
+REMARK 465     LEU C   691                                                      
+REMARK 465     GLN C   692                                                      
+REMARK 465     LEU C   693                                                      
+REMARK 465     VAL C   694                                                      
+REMARK 465     LYS C   695                                                      
+REMARK 465     GLY C   696                                                      
+REMARK 465     PRO C   716                                                      
+REMARK 465     ILE C   717                                                      
+REMARK 465     GLU C   718                                                      
+REMARK 465     SER C   719                                                      
+REMARK 465     SER C   720                                                      
+REMARK 470                                                                      
+REMARK 470 MISSING ATOM                                                         
+REMARK 470 THE FOLLOWING RESIDUES HAVE MISSING ATOMS (M=MODEL NUMBER;           
+REMARK 470 RES=RESIDUE NAME; C=CHAIN IDENTIFIER; SSEQ=SEQUENCE NUMBER;          
+REMARK 470 I=INSERTION CODE):                                                   
+REMARK 470   M RES CSSEQI  ATOMS                                                
+REMARK 470     GLU A  21    CG   CD   OE1  OE2                                  
+REMARK 470     LYS A  24    CG   CD   CE   NZ                                   
+REMARK 470     LYS A  26    CG   CD   CE   NZ                                   
+REMARK 470     LYS A  28    CG   CD   CE   NZ                                   
+REMARK 470     LYS A  29    CG   CD   CE   NZ                                   
+REMARK 470     LYS A  33    CG   CD   CE   NZ                                   
+REMARK 470     GLU A  45    CG   CD   OE1  OE2                                  
+REMARK 470     GLU A  51    CG   CD   OE1  OE2                                  
+REMARK 470     LYS A  55    CG   CD   CE   NZ                                   
+REMARK 470     GLU A  58    CG   CD   OE1  OE2                                  
+REMARK 470     GLU A  86    CG   CD   OE1  OE2                                  
+REMARK 470     HIS A  90    CG   ND1  CD2  CE1  NE2                             
+REMARK 470     SER B  -2    OG                                                  
+REMARK 470     LYS B  55    CG   CD   CE   NZ                                   
+REMARK 470     PHE B  88    CG   CD1  CD2  CE1  CE2  CZ                         
+REMARK 500                                                                      
+REMARK 500 GEOMETRY AND STEREOCHEMISTRY                                         
+REMARK 500 SUBTOPIC: TORSION ANGLES                                             
+REMARK 500                                                                      
+REMARK 500 TORSION ANGLES OUTSIDE THE EXPECTED RAMACHANDRAN REGIONS:            
+REMARK 500 (M=MODEL NUMBER; RES=RESIDUE NAME; C=CHAIN IDENTIFIER;               
+REMARK 500 SSEQ=SEQUENCE NUMBER; I=INSERTION CODE).                             
+REMARK 500                                                                      
+REMARK 500 STANDARD TABLE:                                                      
+REMARK 500 FORMAT:(10X,I3,1X,A3,1X,A1,I4,A1,4X,F7.2,3X,F7.2)                    
+REMARK 500                                                                      
+REMARK 500 EXPECTED VALUES: GJ KLEYWEGT AND TA JONES (1996). PHI/PSI-           
+REMARK 500 CHOLOGY: RAMACHANDRAN REVISITED. STRUCTURE 4, 1395 - 1400            
+REMARK 500                                                                      
+REMARK 500  M RES CSSEQI        PSI       PHI                                   
+REMARK 500    PHE A  87       34.86    -91.66                                   
+REMARK 500    PHE A  88      -13.10   -141.89                                   
+REMARK 500    HIS B  -1      113.37   -173.33                                   
+REMARK 500    MET B   0      124.63     -9.06                                   
+REMARK 500    PHE B  87       32.02    -92.66                                   
+REMARK 500    PRO C 712     -139.78    -74.13                                   
+REMARK 500                                                                      
+REMARK 500 REMARK: NULL                                                         
+REMARK 620                                                                      
+REMARK 620 METAL COORDINATION                                                   
+REMARK 620 (M=MODEL NUMBER; RES=RESIDUE NAME; C=CHAIN IDENTIFIER;               
+REMARK 620 SSEQ=SEQUENCE NUMBER; I=INSERTION CODE):                             
+REMARK 620                                                                      
+REMARK 620 COORDINATION ANGLES FOR:  M RES CSSEQI METAL                         
+REMARK 620                              CA A 101  CA                            
+REMARK 620 N RES CSSEQI ATOM                                                    
+REMARK 620 1 SER A  18   O                                                      
+REMARK 620 2 GLU A  21   O   107.4                                              
+REMARK 620 3 ASP A  23   O    73.5 100.2                                        
+REMARK 620 4 LYS A  26   O    87.6 164.4  79.8                                  
+REMARK 620 5 GLU A  31   OE1  77.7  66.7 142.9 122.2                            
+REMARK 620 6 GLU A  31   OE2 113.7  96.2 159.1  81.0  56.5                      
+REMARK 620 N                    1     2     3     4     5                       
+REMARK 620                                                                      
+REMARK 620 COORDINATION ANGLES FOR:  M RES CSSEQI METAL                         
+REMARK 620                              CA A 102  CA                            
+REMARK 620 N RES CSSEQI ATOM                                                    
+REMARK 620 1 ASP A  61   OD1                                                    
+REMARK 620 2 ASP A  63   OD1  59.4                                              
+REMARK 620 3 ASP A  65   OD1  83.8  89.9                                        
+REMARK 620 4 GLU A  67   O   102.0 161.4  86.4                                  
+REMARK 620 5 GLU A  72   OE1 114.1 109.9 158.0  77.7                            
+REMARK 620 6 GLU A  72   OE2  70.1  58.4 146.0 119.4  56.0                      
+REMARK 620 N                    1     2     3     4     5                       
+REMARK 620                                                                      
+REMARK 620 COORDINATION ANGLES FOR:  M RES CSSEQI METAL                         
+REMARK 620                              CA B 101  CA                            
+REMARK 620 N RES CSSEQI ATOM                                                    
+REMARK 620 1 SER B  18   O                                                      
+REMARK 620 2 GLU B  21   O   114.1                                              
+REMARK 620 3 ASP B  23   O    75.5  96.5                                        
+REMARK 620 4 LYS B  26   O    83.5 159.4  76.9                                  
+REMARK 620 5 GLU B  31   OE1 104.4 104.2 156.9  80.1                            
+REMARK 620 6 GLU B  31   OE2  81.0  70.4 145.5 125.3  54.3                      
+REMARK 620 N                    1     2     3     4     5                       
+REMARK 620                                                                      
+REMARK 620 COORDINATION ANGLES FOR:  M RES CSSEQI METAL                         
+REMARK 620                              CA B 102  CA                            
+REMARK 620 N RES CSSEQI ATOM                                                    
+REMARK 620 1 ASP B  61   OD1                                                    
+REMARK 620 2 ASP B  63   OD1  61.6                                              
+REMARK 620 3 ASP B  63   OD2 107.8  47.1                                        
+REMARK 620 4 ASP B  65   OD1  70.8  89.0  96.1                                  
+REMARK 620 5 ASP B  65   OD2 119.8  95.5  64.3  52.7                            
+REMARK 620 6 GLU B  67   O    78.9 140.3 164.9  73.0 100.6                      
+REMARK 620 7 GLU B  72   OE1 101.0 108.6 109.3 154.6 138.9  81.9                
+REMARK 620 8 GLU B  72   OE2  65.5  57.2  83.3 133.7 147.5 111.7  53.4          
+REMARK 620 N                    1     2     3     4     5     6     7           
+REMARK 800                                                                      
+REMARK 800 SITE                                                                 
+REMARK 800 SITE_IDENTIFIER: AC1                                                 
+REMARK 800 EVIDENCE_CODE: SOFTWARE                                              
+REMARK 800 SITE_DESCRIPTION: binding site for residue CA A 101                  
+REMARK 800                                                                      
+REMARK 800 SITE_IDENTIFIER: AC2                                                 
+REMARK 800 EVIDENCE_CODE: SOFTWARE                                              
+REMARK 800 SITE_DESCRIPTION: binding site for residue CA A 102                  
+REMARK 800                                                                      
+REMARK 800 SITE_IDENTIFIER: AC3                                                 
+REMARK 800 EVIDENCE_CODE: SOFTWARE                                              
+REMARK 800 SITE_DESCRIPTION: binding site for residue CA B 101                  
+REMARK 800                                                                      
+REMARK 800 SITE_IDENTIFIER: AC4                                                 
+REMARK 800 EVIDENCE_CODE: SOFTWARE                                              
+REMARK 800 SITE_DESCRIPTION: binding site for residue CA B 102                  
+DBREF  5CSN A    0    91  UNP    P04271   S100B_HUMAN      1     92             
+DBREF  5CSN B    0    91  UNP    P04271   S100B_HUMAN      1     92             
+DBREF  5CSN C  683   720  UNP    Q15418   KS6A1_HUMAN    683    720             
+SEQADV 5CSN GLY A   -3  UNP  P04271              EXPRESSION TAG                 
+SEQADV 5CSN SER A   -2  UNP  P04271              EXPRESSION TAG                 
+SEQADV 5CSN HIS A   -1  UNP  P04271              EXPRESSION TAG                 
+SEQADV 5CSN GLY B   -3  UNP  P04271              EXPRESSION TAG                 
+SEQADV 5CSN SER B   -2  UNP  P04271              EXPRESSION TAG                 
+SEQADV 5CSN HIS B   -1  UNP  P04271              EXPRESSION TAG                 
+SEQADV 5CSN GLY C  681  UNP  Q15418              EXPRESSION TAG                 
+SEQADV 5CSN SER C  682  UNP  Q15418              EXPRESSION TAG                 
+SEQRES   1 A   95  GLY SER HIS MET SER GLU LEU GLU LYS ALA MET VAL ALA          
+SEQRES   2 A   95  LEU ILE ASP VAL PHE HIS GLN TYR SER GLY ARG GLU GLY          
+SEQRES   3 A   95  ASP LYS HIS LYS LEU LYS LYS SER GLU LEU LYS GLU LEU          
+SEQRES   4 A   95  ILE ASN ASN GLU LEU SER HIS PHE LEU GLU GLU ILE LYS          
+SEQRES   5 A   95  GLU GLN GLU VAL VAL ASP LYS VAL MET GLU THR LEU ASP          
+SEQRES   6 A   95  ASN ASP GLY ASP GLY GLU CYS ASP PHE GLN GLU PHE MET          
+SEQRES   7 A   95  ALA PHE VAL ALA MET VAL THR THR ALA CYS HIS GLU PHE          
+SEQRES   8 A   95  PHE GLU HIS GLU                                              
+SEQRES   1 B   95  GLY SER HIS MET SER GLU LEU GLU LYS ALA MET VAL ALA          
+SEQRES   2 B   95  LEU ILE ASP VAL PHE HIS GLN TYR SER GLY ARG GLU GLY          
+SEQRES   3 B   95  ASP LYS HIS LYS LEU LYS LYS SER GLU LEU LYS GLU LEU          
+SEQRES   4 B   95  ILE ASN ASN GLU LEU SER HIS PHE LEU GLU GLU ILE LYS          
+SEQRES   5 B   95  GLU GLN GLU VAL VAL ASP LYS VAL MET GLU THR LEU ASP          
+SEQRES   6 B   95  ASN ASP GLY ASP GLY GLU CYS ASP PHE GLN GLU PHE MET          
+SEQRES   7 B   95  ALA PHE VAL ALA MET VAL THR THR ALA CYS HIS GLU PHE          
+SEQRES   8 B   95  PHE GLU HIS GLU                                              
+SEQRES   1 C   40  GLY SER GLN SER GLN LEU SER HIS GLN ASP LEU GLN LEU          
+SEQRES   2 C   40  VAL LYS GLY ALA MET ALA ALA THR TYR SER ALA LEU ASN          
+SEQRES   3 C   40  SER SER LYS PRO THR PRO GLN LEU LYS PRO ILE GLU SER          
+SEQRES   4 C   40  SER                                                          
+HET     CA  A 101       1                                                       
+HET     CA  A 102       1                                                       
+HET     CA  B 101       1                                                       
+HET     CA  B 102       1                                                       
+HETNAM      CA CALCIUM ION                                                      
+FORMUL   4   CA    4(CA 2+)                                                     
+HELIX    1 AA1 SER A    1  GLY A   19  1                                  19    
+HELIX    2 AA2 LYS A   28  LEU A   40  1                                  13    
+HELIX    3 AA3 GLU A   49  ASP A   61  1                                  13    
+HELIX    4 AA4 ASP A   69  PHE A   87  1                                  19    
+HELIX    5 AA5 SER B    1  GLY B   19  1                                  19    
+HELIX    6 AA6 LYS B   28  LEU B   40  1                                  13    
+HELIX    7 AA7 GLU B   49  ASP B   61  1                                  13    
+HELIX    8 AA8 ASP B   69  PHE B   87  1                                  19    
+HELIX    9 AA9 ALA C  700  ASN C  706  1                                   7    
+LINK         O   SER A  18                CA    CA A 101     1555   1555  2.44  
+LINK         O   GLU A  21                CA    CA A 101     1555   1555  2.42  
+LINK         O   ASP A  23                CA    CA A 101     1555   1555  2.27  
+LINK         O   LYS A  26                CA    CA A 101     1555   1555  2.47  
+LINK         OE1 GLU A  31                CA    CA A 101     1555   1555  2.32  
+LINK         OE2 GLU A  31                CA    CA A 101     1555   1555  2.33  
+LINK         OD1 ASP A  61                CA    CA A 102     1555   1555  2.35  
+LINK         OD1 ASP A  63                CA    CA A 102     1555   1555  2.40  
+LINK         OD1 ASP A  65                CA    CA A 102     1555   1555  2.29  
+LINK         O   GLU A  67                CA    CA A 102     1555   1555  2.37  
+LINK         OE1 GLU A  72                CA    CA A 102     1555   1555  2.35  
+LINK         OE2 GLU A  72                CA    CA A 102     1555   1555  2.33  
+LINK         O   SER B  18                CA    CA B 101     1555   1555  2.47  
+LINK         O   GLU B  21                CA    CA B 101     1555   1555  2.38  
+LINK         O   ASP B  23                CA    CA B 101     1555   1555  2.35  
+LINK         O   LYS B  26                CA    CA B 101     1555   1555  2.42  
+LINK         OE1 GLU B  31                CA    CA B 101     1555   1555  2.36  
+LINK         OE2 GLU B  31                CA    CA B 101     1555   1555  2.45  
+LINK         OD1 ASP B  61                CA    CA B 102     1555   1555  2.53  
+LINK         OD1 ASP B  63                CA    CA B 102     1555   1555  2.26  
+LINK         OD2 ASP B  63                CA    CA B 102     1555   1555  2.98  
+LINK         OD1 ASP B  65                CA    CA B 102     1555   1555  2.26  
+LINK         OD2 ASP B  65                CA    CA B 102     1555   1555  2.61  
+LINK         O   GLU B  67                CA    CA B 102     1555   1555  2.37  
+LINK         OE1 GLU B  72                CA    CA B 102     1555   1555  2.39  
+LINK         OE2 GLU B  72                CA    CA B 102     1555   1555  2.48  
+CISPEP   1 ALA C  697    MET C  698          0        -2.34                     
+SITE     1 AC1  5 SER A  18  GLU A  21  ASP A  23  LYS A  26                    
+SITE     2 AC1  5 GLU A  31                                                     
+SITE     1 AC2  5 ASP A  61  ASP A  63  ASP A  65  GLU A  67                    
+SITE     2 AC2  5 GLU A  72                                                     
+SITE     1 AC3  5 SER B  18  GLU B  21  ASP B  23  LYS B  26                    
+SITE     2 AC3  5 GLU B  31                                                     
+SITE     1 AC4  5 ASP B  61  ASP B  63  ASP B  65  GLU B  67                    
+SITE     2 AC4  5 GLU B  72                                                     
+CRYST1   36.790   39.930  178.340  90.00  90.00  90.00 P 21 21 21    8          
+ORIGX1      1.000000  0.000000  0.000000        0.00000                         
+ORIGX2      0.000000  1.000000  0.000000        0.00000                         
+ORIGX3      0.000000  0.000000  1.000000        0.00000                         
+SCALE1      0.027181  0.000000  0.000000        0.00000                         
+SCALE2      0.000000  0.025044  0.000000        0.00000                         
+SCALE3      0.000000  0.000000  0.005607        0.00000                         
+ATOM      1  N   GLY A  -3      -5.041  -2.918 -41.019  1.00 46.58           N  
+ATOM      2  CA  GLY A  -3      -5.112  -4.310 -41.423  1.00 43.97           C  
+ATOM      3  C   GLY A  -3      -5.932  -5.146 -40.460  1.00 53.65           C  
+ATOM      4  O   GLY A  -3      -6.571  -4.607 -39.556  1.00 55.60           O  
+ATOM      5  N   SER A  -2      -5.915  -6.464 -40.642  1.00 54.77           N  
+ATOM      6  CA  SER A  -2      -6.679  -7.344 -39.766  1.00 54.09           C  
+ATOM      7  C   SER A  -2      -5.906  -7.703 -38.502  1.00 65.73           C  
+ATOM      8  O   SER A  -2      -6.500  -8.067 -37.487  1.00 60.05           O  
+ATOM      9  CB  SER A  -2      -7.071  -8.620 -40.510  1.00 49.82           C  
+ATOM     10  OG  SER A  -2      -5.934  -9.428 -40.759  1.00 53.11           O  
+ATOM     11  N   HIS A  -1      -4.582  -7.617 -38.564  1.00 62.24           N  
+ATOM     12  CA  HIS A  -1      -3.767  -7.798 -37.370  1.00 57.17           C  
+ATOM     13  C   HIS A  -1      -3.909  -6.578 -36.470  1.00 48.27           C  
+ATOM     14  O   HIS A  -1      -4.130  -5.468 -36.957  1.00 62.58           O  
+ATOM     15  CB  HIS A  -1      -2.299  -8.044 -37.728  1.00 56.91           C  
+ATOM     16  CG  HIS A  -1      -2.065  -9.316 -38.483  1.00 59.95           C  
+ATOM     17  ND1 HIS A  -1      -0.806  -9.841 -38.682  1.00 55.18           N  
+ATOM     18  CD2 HIS A  -1      -2.929 -10.176 -39.072  1.00 59.63           C  
+ATOM     19  CE1 HIS A  -1      -0.904 -10.965 -39.369  1.00 49.80           C  
+ATOM     20  NE2 HIS A  -1      -2.181 -11.191 -39.618  1.00 51.00           N  
+ATOM     21  N   MET A   0      -3.814  -6.786 -35.162  1.00 50.12           N  
+ATOM     22  CA  MET A   0      -3.648  -5.681 -34.227  1.00 48.53           C  
+ATOM     23  C   MET A   0      -2.468  -4.812 -34.652  1.00 49.77           C  
+ATOM     24  O   MET A   0      -1.361  -5.315 -34.841  1.00 65.91           O  
+ATOM     25  CB  MET A   0      -3.450  -6.200 -32.803  1.00 47.41           C  
+ATOM     26  CG  MET A   0      -4.717  -6.763 -32.184  1.00 55.69           C  
+ATOM     27  SD  MET A   0      -5.927  -5.486 -31.792  1.00 73.00           S  
+ATOM     28  CE  MET A   0      -7.389  -6.484 -31.519  1.00 84.64           C  
+ATOM     29  N   SER A   1      -2.700  -3.513 -34.801  1.00 46.30           N  
+ATOM     30  CA  SER A   1      -1.640  -2.623 -35.253  1.00 42.21           C  
+ATOM     31  C   SER A   1      -0.692  -2.316 -34.107  1.00 37.36           C  
+ATOM     32  O   SER A   1      -0.992  -2.606 -32.951  1.00 50.58           O  
+ATOM     33  CB  SER A   1      -2.221  -1.326 -35.817  1.00 50.14           C  
+ATOM     34  OG  SER A   1      -2.904  -0.599 -34.812  1.00 48.54           O  
+ATOM     35  N   GLU A   2       0.450  -1.724 -34.436  1.00 54.87           N  
+ATOM     36  CA  GLU A   2       1.382  -1.244 -33.426  1.00 40.76           C  
+ATOM     37  C   GLU A   2       0.712  -0.214 -32.529  1.00 44.79           C  
+ATOM     38  O   GLU A   2       0.878  -0.238 -31.309  1.00 56.57           O  
+ATOM     39  CB  GLU A   2       2.625  -0.644 -34.086  1.00 57.26           C  
+ATOM     40  CG  GLU A   2       3.428  -1.633 -34.921  1.00 42.94           C  
+ATOM     41  CD  GLU A   2       2.916  -1.756 -36.345  1.00 65.54           C  
+ATOM     42  OE1 GLU A   2       1.753  -1.377 -36.602  1.00 63.01           O  
+ATOM     43  OE2 GLU A   2       3.679  -2.236 -37.210  1.00 86.02           O1-
+ATOM     44  N   LEU A   3      -0.045   0.689 -33.147  1.00 57.95           N  
+ATOM     45  CA  LEU A   3      -0.820   1.685 -32.416  1.00 41.95           C  
+ATOM     46  C   LEU A   3      -1.784   1.037 -31.427  1.00 52.22           C  
+ATOM     47  O   LEU A   3      -1.863   1.448 -30.270  1.00 62.21           O  
+ATOM     48  CB  LEU A   3      -1.590   2.577 -33.393  1.00 49.19           C  
+ATOM     49  CG  LEU A   3      -2.486   3.676 -32.817  1.00 56.24           C  
+ATOM     50  CD1 LEU A   3      -1.765   4.467 -31.738  1.00 52.40           C  
+ATOM     51  CD2 LEU A   3      -2.963   4.596 -33.928  1.00 41.24           C  
+ATOM     52  N   GLU A   4      -2.520   0.030 -31.886  1.00 52.84           N  
+ATOM     53  CA  GLU A   4      -3.546  -0.580 -31.050  1.00 45.70           C  
+ATOM     54  C   GLU A   4      -2.943  -1.388 -29.906  1.00 55.54           C  
+ATOM     55  O   GLU A   4      -3.522  -1.455 -28.826  1.00 55.34           O  
+ATOM     56  CB  GLU A   4      -4.461  -1.471 -31.893  1.00 48.95           C  
+ATOM     57  CG  GLU A   4      -5.409  -0.704 -32.798  1.00 52.06           C  
+ATOM     58  CD  GLU A   4      -6.112  -1.599 -33.801  1.00 56.60           C  
+ATOM     59  OE1 GLU A   4      -5.470  -2.539 -34.315  1.00 53.48           O  
+ATOM     60  OE2 GLU A   4      -7.307  -1.360 -34.076  1.00 60.80           O1-
+ATOM     61  N   LYS A   5      -1.775  -1.982 -30.136  1.00 49.43           N  
+ATOM     62  CA  LYS A   5      -1.091  -2.747 -29.094  1.00 42.12           C  
+ATOM     63  C   LYS A   5      -0.364  -1.821 -28.126  1.00 51.63           C  
+ATOM     64  O   LYS A   5      -0.116  -2.178 -26.974  1.00 58.19           O  
+ATOM     65  CB  LYS A   5      -0.121  -3.762 -29.702  1.00 47.04           C  
+ATOM     66  CG  LYS A   5      -0.786  -4.769 -30.630  1.00 47.28           C  
+ATOM     67  CD  LYS A   5       0.121  -5.957 -30.914  1.00 52.81           C  
+ATOM     68  CE  LYS A   5       1.181  -5.623 -31.945  1.00 45.50           C  
+ATOM     69  NZ  LYS A   5       1.586  -6.827 -32.720  1.00 81.28           N1+
+ATOM     70  N   ALA A   6      -0.028  -0.629 -28.605  1.00 52.07           N  
+ATOM     71  CA  ALA A   6       0.535   0.410 -27.756  1.00 57.62           C  
+ATOM     72  C   ALA A   6      -0.510   0.828 -26.734  1.00 61.86           C  
+ATOM     73  O   ALA A   6      -0.228   0.914 -25.539  1.00 69.66           O  
+ATOM     74  CB  ALA A   6       0.991   1.600 -28.583  1.00 56.24           C  
+ATOM     75  N   MET A   7      -1.716   1.092 -27.225  1.00 51.29           N  
+ATOM     76  CA  MET A   7      -2.839   1.487 -26.383  1.00 62.71           C  
+ATOM     77  C   MET A   7      -3.108   0.424 -25.318  1.00 58.76           C  
+ATOM     78  O   MET A   7      -3.297   0.749 -24.146  1.00 71.91           O  
+ATOM     79  CB  MET A   7      -4.084   1.723 -27.239  1.00 78.56           C  
+ATOM     80  CG  MET A   7      -3.988   2.959 -28.125  1.00 57.13           C  
+ATOM     81  SD  MET A   7      -5.389   3.159 -29.242  1.00 59.67           S  
+ATOM     82  CE  MET A   7      -5.180   4.866 -29.743  1.00 62.24           C  
+ATOM     83  N   VAL A   8      -3.137  -0.840 -25.735  1.00 56.80           N  
+ATOM     84  CA  VAL A   8      -3.312  -1.959 -24.810  1.00 60.36           C  
+ATOM     85  C   VAL A   8      -2.229  -1.951 -23.734  1.00 63.04           C  
+ATOM     86  O   VAL A   8      -2.500  -2.219 -22.563  1.00 69.87           O  
+ATOM     87  CB  VAL A   8      -3.293  -3.323 -25.539  1.00 56.82           C  
+ATOM     88  CG1 VAL A   8      -3.464  -4.463 -24.548  1.00 55.66           C  
+ATOM     89  CG2 VAL A   8      -4.375  -3.379 -26.600  1.00 51.55           C  
+ATOM     90  N   ALA A   9      -1.003  -1.628 -24.133  1.00 58.43           N  
+ATOM     91  CA  ALA A   9       0.123  -1.658 -23.210  1.00 58.18           C  
+ATOM     92  C   ALA A   9      -0.030  -0.576 -22.149  1.00 62.78           C  
+ATOM     93  O   ALA A   9       0.377  -0.761 -21.003  1.00 79.53           O  
+ATOM     94  CB  ALA A   9       1.432  -1.487 -23.961  1.00 58.92           C  
+ATOM     95  N   LEU A  10      -0.610   0.556 -22.536  1.00 69.93           N  
+ATOM     96  CA  LEU A  10      -0.869   1.633 -21.590  1.00 56.07           C  
+ATOM     97  C   LEU A  10      -1.851   1.151 -20.527  1.00 65.56           C  
+ATOM     98  O   LEU A  10      -1.676   1.403 -19.336  1.00 78.09           O  
+ATOM     99  CB  LEU A  10      -1.427   2.864 -22.307  1.00 52.75           C  
+ATOM    100  CG  LEU A  10      -0.594   3.454 -23.447  1.00 53.99           C  
+ATOM    101  CD1 LEU A  10      -1.196   4.764 -23.929  1.00 61.57           C  
+ATOM    102  CD2 LEU A  10       0.841   3.661 -23.003  1.00 61.67           C  
+ATOM    103  N   ILE A  11      -2.890   0.458 -20.984  1.00 68.29           N  
+ATOM    104  CA  ILE A  11      -3.888  -0.145 -20.108  1.00 76.11           C  
+ATOM    105  C   ILE A  11      -3.287  -1.206 -19.186  1.00 82.36           C  
+ATOM    106  O   ILE A  11      -3.602  -1.262 -17.995  1.00 91.82           O  
+ATOM    107  CB  ILE A  11      -5.035  -0.773 -20.926  1.00 66.87           C  
+ATOM    108  CG1 ILE A  11      -5.747   0.303 -21.750  1.00 60.56           C  
+ATOM    109  CG2 ILE A  11      -6.021  -1.491 -20.015  1.00 74.94           C  
+ATOM    110  CD1 ILE A  11      -6.644  -0.252 -22.834  1.00 67.89           C  
+ATOM    111  N   ASP A  12      -2.409  -2.038 -19.740  1.00 71.21           N  
+ATOM    112  CA  ASP A  12      -1.837  -3.152 -18.992  1.00 70.00           C  
+ATOM    113  C   ASP A  12      -0.898  -2.686 -17.889  1.00 77.27           C  
+ATOM    114  O   ASP A  12      -0.936  -3.211 -16.777  1.00 91.88           O  
+ATOM    115  CB  ASP A  12      -1.092  -4.098 -19.936  1.00 71.86           C  
+ATOM    116  CG  ASP A  12      -2.021  -4.817 -20.893  1.00 91.93           C  
+ATOM    117  OD1 ASP A  12      -3.253  -4.747 -20.693  1.00 83.59           O  
+ATOM    118  OD2 ASP A  12      -1.521  -5.454 -21.844  1.00 78.78           O1-
+ATOM    119  N   VAL A  13      -0.060  -1.701 -18.195  1.00 77.21           N  
+ATOM    120  CA  VAL A  13       0.903  -1.201 -17.221  1.00 78.95           C  
+ATOM    121  C   VAL A  13       0.175  -0.512 -16.066  1.00 86.25           C  
+ATOM    122  O   VAL A  13       0.643  -0.535 -14.928  1.00103.99           O  
+ATOM    123  CB  VAL A  13       1.936  -0.240 -17.867  1.00 75.74           C  
+ATOM    124  CG1 VAL A  13       1.305   1.092 -18.247  1.00 73.91           C  
+ATOM    125  CG2 VAL A  13       3.122  -0.033 -16.937  1.00 87.19           C  
+ATOM    126  N   PHE A  14      -0.969   0.100 -16.362  1.00 77.76           N  
+ATOM    127  CA  PHE A  14      -1.767   0.753 -15.333  1.00 74.86           C  
+ATOM    128  C   PHE A  14      -2.318  -0.286 -14.359  1.00 93.20           C  
+ATOM    129  O   PHE A  14      -2.177  -0.141 -13.145  1.00101.16           O  
+ATOM    130  CB  PHE A  14      -2.905   1.562 -15.959  1.00 82.95           C  
+ATOM    131  CG  PHE A  14      -3.802   2.228 -14.953  1.00 96.61           C  
+ATOM    132  CD1 PHE A  14      -3.408   3.396 -14.321  1.00 90.25           C  
+ATOM    133  CD2 PHE A  14      -5.042   1.691 -14.644  1.00 99.66           C  
+ATOM    134  CE1 PHE A  14      -4.229   4.014 -13.397  1.00 91.77           C  
+ATOM    135  CE2 PHE A  14      -5.868   2.305 -13.720  1.00 90.94           C  
+ATOM    136  CZ  PHE A  14      -5.461   3.468 -13.096  1.00 94.25           C  
+ATOM    137  N   HIS A  15      -2.943  -1.332 -14.894  1.00 94.90           N  
+ATOM    138  CA  HIS A  15      -3.527  -2.373 -14.054  1.00 94.98           C  
+ATOM    139  C   HIS A  15      -2.443  -3.174 -13.343  1.00 99.15           C  
+ATOM    140  O   HIS A  15      -2.659  -3.696 -12.250  1.00101.82           O  
+ATOM    141  CB  HIS A  15      -4.392  -3.326 -14.886  1.00 88.41           C  
+ATOM    142  CG  HIS A  15      -5.709  -2.751 -15.303  1.00101.01           C  
+ATOM    143  ND1 HIS A  15      -6.704  -2.439 -14.402  1.00109.35           N  
+ATOM    144  CD2 HIS A  15      -6.205  -2.455 -16.528  1.00109.50           C  
+ATOM    145  CE1 HIS A  15      -7.751  -1.964 -15.053  1.00106.25           C  
+ATOM    146  NE2 HIS A  15      -7.474  -1.964 -16.344  1.00111.65           N  
+ATOM    147  N   GLN A  16      -1.278  -3.268 -13.978  1.00 97.87           N  
+ATOM    148  CA  GLN A  16      -0.117  -3.924 -13.384  1.00104.14           C  
+ATOM    149  C   GLN A  16       0.315  -3.286 -12.066  1.00 93.15           C  
+ATOM    150  O   GLN A  16       0.800  -3.971 -11.164  1.00107.86           O  
+ATOM    151  CB  GLN A  16       1.052  -3.907 -14.377  1.00104.01           C  
+ATOM    152  CG  GLN A  16       2.376  -4.415 -13.821  1.00111.45           C  
+ATOM    153  CD  GLN A  16       3.489  -4.397 -14.854  1.00107.89           C  
+ATOM    154  OE1 GLN A  16       3.253  -4.144 -16.035  1.00110.27           O  
+ATOM    155  NE2 GLN A  16       4.713  -4.665 -14.410  1.00 95.78           N  
+ATOM    156  N   TYR A  17       0.117  -1.978 -11.949  1.00 90.20           N  
+ATOM    157  CA  TYR A  17       0.556  -1.253 -10.762  1.00100.40           C  
+ATOM    158  C   TYR A  17      -0.574  -0.806  -9.840  1.00106.72           C  
+ATOM    159  O   TYR A  17      -0.397  -0.751  -8.624  1.00117.61           O  
+ATOM    160  CB  TYR A  17       1.396  -0.044 -11.175  1.00 94.08           C  
+ATOM    161  CG  TYR A  17       2.807  -0.417 -11.569  1.00107.40           C  
+ATOM    162  CD1 TYR A  17       3.119  -0.747 -12.881  1.00104.43           C  
+ATOM    163  CD2 TYR A  17       3.822  -0.465 -10.622  1.00105.66           C  
+ATOM    164  CE1 TYR A  17       4.406  -1.097 -13.244  1.00 97.59           C  
+ATOM    165  CE2 TYR A  17       5.112  -0.818 -10.974  1.00106.06           C  
+ATOM    166  CZ  TYR A  17       5.398  -1.130 -12.287  1.00100.02           C  
+ATOM    167  OH  TYR A  17       6.680  -1.482 -12.642  1.00 96.45           O  
+ATOM    168  N   SER A  18      -1.730  -0.479 -10.407  1.00 96.19           N  
+ATOM    169  CA  SER A  18      -2.857  -0.057  -9.584  1.00103.10           C  
+ATOM    170  C   SER A  18      -3.448  -1.213  -8.785  1.00111.01           C  
+ATOM    171  O   SER A  18      -4.081  -0.995  -7.752  1.00110.99           O  
+ATOM    172  CB  SER A  18      -3.942   0.580 -10.454  1.00104.47           C  
+ATOM    173  OG  SER A  18      -4.594  -0.393 -11.253  1.00113.69           O  
+ATOM    174  N   GLY A  19      -3.208  -2.438  -9.245  1.00111.70           N  
+ATOM    175  CA  GLY A  19      -3.772  -3.615  -8.606  1.00112.50           C  
+ATOM    176  C   GLY A  19      -2.989  -4.087  -7.397  1.00118.07           C  
+ATOM    177  O   GLY A  19      -3.387  -5.038  -6.723  1.00126.42           O  
+ATOM    178  N   ARG A  20      -1.870  -3.425  -7.124  1.00126.81           N  
+ATOM    179  CA  ARG A  20      -0.920  -3.895  -6.120  1.00126.08           C  
+ATOM    180  C   ARG A  20      -1.437  -3.666  -4.703  1.00117.75           C  
+ATOM    181  O   ARG A  20      -1.625  -4.615  -3.942  1.00113.66           O  
+ATOM    182  CB  ARG A  20       0.443  -3.225  -6.308  1.00115.50           C  
+ATOM    183  CG  ARG A  20       1.058  -3.477  -7.676  1.00109.00           C  
+ATOM    184  CD  ARG A  20       2.549  -3.185  -7.684  1.00104.29           C  
+ATOM    185  NE  ARG A  20       3.194  -3.694  -8.891  1.00102.24           N  
+ATOM    186  CZ  ARG A  20       4.505  -3.662  -9.110  1.00112.82           C  
+ATOM    187  NH1 ARG A  20       5.319  -3.144  -8.200  1.00112.81           N1+
+ATOM    188  NH2 ARG A  20       5.003  -4.151 -10.237  1.00114.77           N  
+ATOM    189  N   GLU A  21      -1.663  -2.404  -4.352  1.00124.15           N  
+ATOM    190  CA  GLU A  21      -2.119  -2.055  -3.011  1.00124.72           C  
+ATOM    191  C   GLU A  21      -3.431  -1.275  -3.042  1.00128.64           C  
+ATOM    192  O   GLU A  21      -3.642  -0.420  -3.905  1.00136.50           O  
+ATOM    193  CB  GLU A  21      -1.046  -1.243  -2.280  1.00112.98           C  
+ATOM    194  N   GLY A  22      -4.305  -1.581  -2.086  1.00129.76           N  
+ATOM    195  CA  GLY A  22      -5.564  -0.875  -1.916  1.00118.60           C  
+ATOM    196  C   GLY A  22      -6.488  -1.008  -3.111  1.00123.28           C  
+ATOM    197  O   GLY A  22      -6.710  -2.111  -3.612  1.00118.53           O  
+ATOM    198  N   ASP A  23      -7.040   0.118  -3.553  1.00125.77           N  
+ATOM    199  CA  ASP A  23      -7.943   0.148  -4.700  1.00117.02           C  
+ATOM    200  C   ASP A  23      -7.196  -0.363  -5.930  1.00122.43           C  
+ATOM    201  O   ASP A  23      -6.204   0.230  -6.346  1.00115.90           O  
+ATOM    202  CB  ASP A  23      -8.475   1.566  -4.928  1.00107.17           C  
+ATOM    203  CG  ASP A  23      -9.589   1.623  -5.961  1.00107.91           C  
+ATOM    204  OD1 ASP A  23      -9.755   0.659  -6.738  1.00118.21           O  
+ATOM    205  OD2 ASP A  23     -10.306   2.644  -5.994  1.00104.28           O1-
+ATOM    206  N   LYS A  24      -7.687  -1.447  -6.524  1.00124.07           N  
+ATOM    207  CA  LYS A  24      -6.988  -2.080  -7.639  1.00123.90           C  
+ATOM    208  C   LYS A  24      -7.136  -1.312  -8.952  1.00120.79           C  
+ATOM    209  O   LYS A  24      -6.493  -1.642  -9.948  1.00111.92           O  
+ATOM    210  CB  LYS A  24      -7.485  -3.516  -7.825  1.00106.92           C  
+ATOM    211  N   HIS A  25      -7.982  -0.288  -8.947  1.00115.63           N  
+ATOM    212  CA  HIS A  25      -8.266   0.480 -10.155  1.00115.38           C  
+ATOM    213  C   HIS A  25      -7.697   1.898 -10.100  1.00111.03           C  
+ATOM    214  O   HIS A  25      -7.937   2.705 -10.998  1.00120.28           O  
+ATOM    215  CB  HIS A  25      -9.770   0.507 -10.425  1.00118.90           C  
+ATOM    216  CG  HIS A  25     -10.331  -0.832 -10.792  1.00132.84           C  
+ATOM    217  ND1 HIS A  25      -9.701  -1.679 -11.679  1.00139.32           N  
+ATOM    218  CD2 HIS A  25     -11.455  -1.473 -10.393  1.00149.76           C  
+ATOM    219  CE1 HIS A  25     -10.414  -2.783 -11.812  1.00143.87           C  
+ATOM    220  NE2 HIS A  25     -11.483  -2.683 -11.043  1.00160.24           N  
+ATOM    221  N   LYS A  26      -6.942   2.196  -9.048  1.00101.21           N  
+ATOM    222  CA  LYS A  26      -6.323   3.510  -8.902  1.00 97.02           C  
+ATOM    223  C   LYS A  26      -4.897   3.368  -8.384  1.00106.93           C  
+ATOM    224  O   LYS A  26      -4.555   2.371  -7.749  1.00110.26           O  
+ATOM    225  CB  LYS A  26      -7.145   4.393  -7.962  1.00106.14           C  
+ATOM    226  N   LEU A  27      -4.069   4.374  -8.651  1.00108.89           N  
+ATOM    227  CA  LEU A  27      -2.708   4.394  -8.127  1.00108.40           C  
+ATOM    228  C   LEU A  27      -2.516   5.311  -6.925  1.00117.39           C  
+ATOM    229  O   LEU A  27      -2.585   6.534  -7.048  1.00117.03           O  
+ATOM    230  CB  LEU A  27      -1.739   4.824  -9.233  1.00115.07           C  
+ATOM    231  CG  LEU A  27      -1.599   3.932 -10.466  1.00109.49           C  
+ATOM    232  CD1 LEU A  27      -1.057   4.731 -11.639  1.00104.95           C  
+ATOM    233  CD2 LEU A  27      -0.690   2.760 -10.167  1.00108.16           C  
+ATOM    234  N   LYS A  28      -2.269   4.713  -5.763  1.00117.43           N  
+ATOM    235  CA  LYS A  28      -1.814   5.464  -4.601  1.00117.41           C  
+ATOM    236  C   LYS A  28      -0.382   5.919  -4.853  1.00111.24           C  
+ATOM    237  O   LYS A  28       0.256   5.449  -5.797  1.00105.20           O  
+ATOM    238  CB  LYS A  28      -1.901   4.618  -3.331  1.00103.45           C  
+ATOM    239  N   LYS A  29       0.119   6.835  -4.027  1.00118.19           N  
+ATOM    240  CA  LYS A  29       1.464   7.374  -4.219  1.00109.22           C  
+ATOM    241  C   LYS A  29       2.488   6.241  -4.228  1.00112.15           C  
+ATOM    242  O   LYS A  29       3.462   6.272  -4.982  1.00108.19           O  
+ATOM    243  CB  LYS A  29       1.803   8.391  -3.127  1.00109.98           C  
+ATOM    244  N   SER A  30       2.255   5.255  -3.365  1.00115.76           N  
+ATOM    245  CA  SER A  30       3.062   4.040  -3.298  1.00118.56           C  
+ATOM    246  C   SER A  30       3.231   3.382  -4.663  1.00113.47           C  
+ATOM    247  O   SER A  30       4.344   3.079  -5.093  1.00111.28           O  
+ATOM    248  CB  SER A  30       2.436   3.043  -2.320  1.00119.28           C  
+ATOM    249  OG  SER A  30       3.036   1.765  -2.440  1.00118.51           O  
+ATOM    250  N   GLU A  31       2.104   3.163  -5.332  1.00111.59           N  
+ATOM    251  CA  GLU A  31       2.067   2.460  -6.608  1.00107.62           C  
+ATOM    252  C   GLU A  31       2.591   3.305  -7.767  1.00105.42           C  
+ATOM    253  O   GLU A  31       3.237   2.787  -8.677  1.00106.33           O  
+ATOM    254  CB  GLU A  31       0.638   2.007  -6.897  1.00 98.57           C  
+ATOM    255  CG  GLU A  31       0.130   0.957  -5.931  1.00100.59           C  
+ATOM    256  CD  GLU A  31      -1.378   0.872  -5.916  1.00109.84           C  
+ATOM    257  OE1 GLU A  31      -1.908  -0.256  -5.839  1.00124.72           O  
+ATOM    258  OE2 GLU A  31      -2.030   1.935  -5.978  1.00103.45           O1-
+ATOM    259  N   LEU A  32       2.299   4.601  -7.728  1.00106.22           N  
+ATOM    260  CA  LEU A  32       2.795   5.548  -8.725  1.00 93.82           C  
+ATOM    261  C   LEU A  32       4.321   5.554  -8.788  1.00 94.52           C  
+ATOM    262  O   LEU A  32       4.909   5.531  -9.869  1.00 97.40           O  
+ATOM    263  CB  LEU A  32       2.283   6.958  -8.428  1.00 97.18           C  
+ATOM    264  CG  LEU A  32       2.766   8.060  -9.374  1.00 96.73           C  
+ATOM    265  CD1 LEU A  32       2.456   7.707 -10.821  1.00104.13           C  
+ATOM    266  CD2 LEU A  32       2.155   9.402  -9.005  1.00 96.23           C  
+ATOM    267  N   LYS A  33       4.948   5.589  -7.617  1.00113.35           N  
+ATOM    268  CA  LYS A  33       6.403   5.597  -7.494  1.00115.99           C  
+ATOM    269  C   LYS A  33       7.055   4.394  -8.172  1.00100.06           C  
+ATOM    270  O   LYS A  33       8.032   4.542  -8.906  1.00 87.44           O  
+ATOM    271  CB  LYS A  33       6.809   5.640  -6.020  1.00118.51           C  
+ATOM    272  N   GLU A  34       6.519   3.206  -7.915  1.00 97.39           N  
+ATOM    273  CA  GLU A  34       7.053   1.989  -8.513  1.00110.32           C  
+ATOM    274  C   GLU A  34       6.930   1.988 -10.037  1.00112.56           C  
+ATOM    275  O   GLU A  34       7.866   1.598 -10.735  1.00116.12           O  
+ATOM    276  CB  GLU A  34       6.329   0.767  -7.942  1.00124.05           C  
+ATOM    277  CG  GLU A  34       6.402   0.642  -6.428  1.00124.46           C  
+ATOM    278  CD  GLU A  34       5.617  -0.548  -5.906  1.00138.17           C  
+ATOM    279  OE1 GLU A  34       5.156  -1.366  -6.730  1.00131.97           O  
+ATOM    280  OE2 GLU A  34       5.462  -0.665  -4.673  1.00149.50           O1-
+ATOM    281  N   LEU A  35       5.775   2.414 -10.544  1.00101.93           N  
+ATOM    282  CA  LEU A  35       5.543   2.494 -11.987  1.00 90.54           C  
+ATOM    283  C   LEU A  35       6.597   3.343 -12.697  1.00 90.63           C  
+ATOM    284  O   LEU A  35       7.274   2.874 -13.612  1.00 92.74           O  
+ATOM    285  CB  LEU A  35       4.140   3.052 -12.262  1.00 84.17           C  
+ATOM    286  CG  LEU A  35       3.574   3.002 -13.686  1.00 87.66           C  
+ATOM    287  CD1 LEU A  35       2.058   2.907 -13.636  1.00 85.50           C  
+ATOM    288  CD2 LEU A  35       3.987   4.218 -14.504  1.00 86.53           C  
+ATOM    289  N   ILE A  36       6.713   4.596 -12.269  1.00 90.29           N  
+ATOM    290  CA  ILE A  36       7.688   5.536 -12.815  1.00 79.30           C  
+ATOM    291  C   ILE A  36       9.129   5.029 -12.760  1.00 91.22           C  
+ATOM    292  O   ILE A  36       9.853   5.083 -13.753  1.00 98.23           O  
+ATOM    293  CB  ILE A  36       7.614   6.889 -12.078  1.00 78.79           C  
+ATOM    294  CG1 ILE A  36       6.271   7.567 -12.354  1.00 85.67           C  
+ATOM    295  CG2 ILE A  36       8.764   7.795 -12.497  1.00 82.88           C  
+ATOM    296  CD1 ILE A  36       6.000   8.766 -11.476  1.00 91.18           C  
+ATOM    297  N   ASN A  37       9.533   4.525 -11.599  1.00103.71           N  
+ATOM    298  CA  ASN A  37      10.915   4.107 -11.391  1.00100.32           C  
+ATOM    299  C   ASN A  37      11.299   2.837 -12.145  1.00 94.24           C  
+ATOM    300  O   ASN A  37      12.453   2.673 -12.542  1.00 96.16           O  
+ATOM    301  CB  ASN A  37      11.174   3.905  -9.895  1.00112.07           C  
+ATOM    302  CG  ASN A  37      11.329   5.216  -9.150  1.00124.41           C  
+ATOM    303  OD1 ASN A  37      11.515   6.271  -9.757  1.00119.68           O  
+ATOM    304  ND2 ASN A  37      11.247   5.158  -7.825  1.00126.42           N  
+ATOM    305  N   ASN A  38      10.337   1.945 -12.354  1.00 97.07           N  
+ATOM    306  CA  ASN A  38      10.623   0.685 -13.031  1.00103.81           C  
+ATOM    307  C   ASN A  38      10.352   0.737 -14.532  1.00100.78           C  
+ATOM    308  O   ASN A  38      11.028   0.069 -15.314  1.00100.29           O  
+ATOM    309  CB  ASN A  38       9.805  -0.448 -12.405  1.00111.78           C  
+ATOM    310  CG  ASN A  38      10.290  -0.824 -11.017  1.00109.55           C  
+ATOM    311  OD1 ASN A  38      11.099  -1.738 -10.856  1.00111.95           O  
+ATOM    312  ND2 ASN A  38       9.794  -0.120 -10.006  1.00105.99           N  
+ATOM    313  N   GLU A  39       9.361   1.528 -14.931  1.00102.84           N  
+ATOM    314  CA  GLU A  39       8.908   1.519 -16.317  1.00 97.23           C  
+ATOM    315  C   GLU A  39       9.221   2.806 -17.083  1.00 86.15           C  
+ATOM    316  O   GLU A  39       9.131   2.829 -18.306  1.00 92.06           O  
+ATOM    317  CB  GLU A  39       7.401   1.245 -16.371  1.00 92.76           C  
+ATOM    318  CG  GLU A  39       6.935   0.104 -15.470  1.00 90.45           C  
+ATOM    319  CD  GLU A  39       7.496  -1.252 -15.871  1.00101.42           C  
+ATOM    320  OE1 GLU A  39       7.970  -1.399 -17.017  1.00 97.85           O  
+ATOM    321  OE2 GLU A  39       7.463  -2.178 -15.033  1.00105.31           O1-
+ATOM    322  N   LEU A  40       9.574   3.875 -16.375  1.00 83.12           N  
+ATOM    323  CA  LEU A  40       9.944   5.130 -17.032  1.00 82.67           C  
+ATOM    324  C   LEU A  40      11.375   5.560 -16.714  1.00 96.27           C  
+ATOM    325  O   LEU A  40      11.675   6.752 -16.659  1.00100.18           O  
+ATOM    326  CB  LEU A  40       8.970   6.244 -16.640  1.00 94.51           C  
+ATOM    327  CG  LEU A  40       7.527   6.079 -17.125  1.00 92.13           C  
+ATOM    328  CD1 LEU A  40       6.636   7.166 -16.546  1.00 67.27           C  
+ATOM    329  CD2 LEU A  40       7.467   6.086 -18.645  1.00 77.70           C  
+ATOM    330  N   SER A  41      12.249   4.582 -16.507  1.00102.62           N  
+ATOM    331  CA  SER A  41      13.627   4.834 -16.087  1.00101.71           C  
+ATOM    332  C   SER A  41      14.538   5.422 -17.169  1.00108.39           C  
+ATOM    333  O   SER A  41      15.727   5.634 -16.929  1.00123.06           O  
+ATOM    334  CB  SER A  41      14.247   3.539 -15.559  1.00 98.66           C  
+ATOM    335  OG  SER A  41      14.461   2.612 -16.611  1.00 95.33           O  
+ATOM    336  N   HIS A  42      13.993   5.683 -18.353  1.00104.32           N  
+ATOM    337  CA  HIS A  42      14.766   6.321 -19.420  1.00104.21           C  
+ATOM    338  C   HIS A  42      14.273   7.712 -19.827  1.00 96.76           C  
+ATOM    339  O   HIS A  42      15.005   8.468 -20.468  1.00 95.65           O  
+ATOM    340  CB  HIS A  42      14.804   5.406 -20.648  1.00106.34           C  
+ATOM    341  CG  HIS A  42      15.520   4.111 -20.412  1.00105.24           C  
+ATOM    342  ND1 HIS A  42      14.864   2.941 -20.094  1.00110.06           N  
+ATOM    343  CD2 HIS A  42      16.838   3.805 -20.447  1.00 98.45           C  
+ATOM    344  CE1 HIS A  42      15.748   1.970 -19.943  1.00110.45           C  
+ATOM    345  NE2 HIS A  42      16.953   2.468 -20.153  1.00113.92           N  
+ATOM    346  N   PHE A  43      13.047   8.055 -19.449  1.00 96.11           N  
+ATOM    347  CA  PHE A  43      12.467   9.340 -19.836  1.00 98.47           C  
+ATOM    348  C   PHE A  43      12.451  10.335 -18.682  1.00100.38           C  
+ATOM    349  O   PHE A  43      12.667  11.530 -18.883  1.00102.26           O  
+ATOM    350  CB  PHE A  43      11.041   9.155 -20.368  1.00113.30           C  
+ATOM    351  CG  PHE A  43      10.965   8.435 -21.688  1.00110.79           C  
+ATOM    352  CD1 PHE A  43      12.109   8.173 -22.425  1.00107.00           C  
+ATOM    353  CD2 PHE A  43       9.742   8.024 -22.194  1.00 94.79           C  
+ATOM    354  CE1 PHE A  43      12.035   7.513 -23.637  1.00 97.40           C  
+ATOM    355  CE2 PHE A  43       9.661   7.363 -23.405  1.00 89.39           C  
+ATOM    356  CZ  PHE A  43      10.809   7.107 -24.127  1.00 85.23           C  
+ATOM    357  N   LEU A  44      12.203   9.842 -17.475  1.00109.81           N  
+ATOM    358  CA  LEU A  44      12.113  10.708 -16.307  1.00114.26           C  
+ATOM    359  C   LEU A  44      13.167  10.356 -15.266  1.00117.68           C  
+ATOM    360  O   LEU A  44      13.501   9.186 -15.076  1.00105.68           O  
+ATOM    361  CB  LEU A  44      10.719  10.622 -15.684  1.00103.83           C  
+ATOM    362  CG  LEU A  44       9.549  11.028 -16.581  1.00 96.79           C  
+ATOM    363  CD1 LEU A  44       8.235  10.867 -15.836  1.00 91.10           C  
+ATOM    364  CD2 LEU A  44       9.724  12.457 -17.073  1.00100.21           C  
+ATOM    365  N   GLU A  45      13.693  11.381 -14.602  1.00123.08           N  
+ATOM    366  CA  GLU A  45      14.678  11.185 -13.546  1.00122.58           C  
+ATOM    367  C   GLU A  45      14.050  10.438 -12.377  1.00125.09           C  
+ATOM    368  O   GLU A  45      12.911  10.709 -11.997  1.00124.34           O  
+ATOM    369  CB  GLU A  45      15.246  12.528 -13.081  1.00100.21           C  
+ATOM    370  N   GLU A  46      14.801   9.486 -11.829  1.00125.28           N  
+ATOM    371  CA  GLU A  46      14.351   8.667 -10.707  1.00128.91           C  
+ATOM    372  C   GLU A  46      13.839   9.512  -9.542  1.00133.19           C  
+ATOM    373  O   GLU A  46      14.382  10.574  -9.237  1.00133.69           O  
+ATOM    374  CB  GLU A  46      15.476   7.738 -10.240  1.00144.29           C  
+ATOM    375  CG  GLU A  46      15.052   6.734  -9.175  1.00144.22           C  
+ATOM    376  CD  GLU A  46      16.229   6.062  -8.496  1.00146.03           C  
+ATOM    377  OE1 GLU A  46      17.383   6.384  -8.846  1.00151.37           O  
+ATOM    378  OE2 GLU A  46      15.998   5.204  -7.619  1.00149.46           O1-
+ATOM    379  N   ILE A  47      12.785   9.021  -8.900  1.00134.33           N  
+ATOM    380  CA  ILE A  47      12.214   9.651  -7.717  1.00144.61           C  
+ATOM    381  C   ILE A  47      12.700   8.970  -6.443  1.00149.52           C  
+ATOM    382  O   ILE A  47      12.545   7.759  -6.280  1.00142.30           O  
+ATOM    383  CB  ILE A  47      10.675   9.611  -7.750  1.00143.22           C  
+ATOM    384  CG1 ILE A  47      10.154  10.178  -9.071  1.00146.03           C  
+ATOM    385  CG2 ILE A  47      10.097  10.369  -6.567  1.00155.84           C  
+ATOM    386  CD1 ILE A  47       8.646  10.199  -9.173  1.00145.98           C  
+ATOM    387  N   LYS A  48      13.289   9.752  -5.542  1.00154.50           N  
+ATOM    388  CA  LYS A  48      13.793   9.210  -4.288  1.00153.18           C  
+ATOM    389  C   LYS A  48      13.365  10.073  -3.112  1.00159.53           C  
+ATOM    390  O   LYS A  48      13.510   9.684  -1.953  1.00167.78           O  
+ATOM    391  CB  LYS A  48      15.321   9.189  -4.311  1.00142.37           C  
+ATOM    392  CG  LYS A  48      15.979   8.242  -5.279  1.00139.53           C  
+ATOM    393  CD  LYS A  48      17.443   8.640  -5.391  1.00143.68           C  
+ATOM    394  CE  LYS A  48      17.564  10.034  -6.008  1.00138.81           C  
+ATOM    395  NZ  LYS A  48      18.972  10.455  -6.250  1.00132.11           N1+
+ATOM    396  N   GLU A  49      12.829  11.247  -3.423  1.00161.15           N  
+ATOM    397  CA  GLU A  49      12.233  12.130  -2.430  1.00164.04           C  
+ATOM    398  C   GLU A  49      10.711  12.079  -2.371  1.00158.01           C  
+ATOM    399  O   GLU A  49      10.044  12.121  -3.404  1.00162.55           O  
+ATOM    400  CB  GLU A  49      12.691  13.566  -2.683  1.00161.93           C  
+ATOM    401  CG  GLU A  49      14.198  13.736  -2.603  1.00166.51           C  
+ATOM    402  CD  GLU A  49      14.624  15.188  -2.577  1.00185.17           C  
+ATOM    403  OE1 GLU A  49      13.752  16.063  -2.394  1.00182.98           O  
+ATOM    404  OE2 GLU A  49      15.834  15.454  -2.737  1.00199.68           O1-
+ATOM    405  N   GLN A  50      10.167  11.984  -1.161  1.00145.28           N  
+ATOM    406  CA  GLN A  50       8.725  11.888  -0.978  1.00145.35           C  
+ATOM    407  C   GLN A  50       8.087  13.195  -1.433  1.00152.66           C  
+ATOM    408  O   GLN A  50       6.964  13.210  -1.938  1.00152.73           O  
+ATOM    409  CB  GLN A  50       8.372  11.594   0.483  1.00139.77           C  
+ATOM    410  CG  GLN A  50       6.874  11.487   0.781  1.00142.97           C  
+ATOM    411  CD  GLN A  50       6.157  10.419  -0.028  1.00147.38           C  
+ATOM    412  OE1 GLN A  50       6.778   9.517  -0.590  1.00160.34           O  
+ATOM    413  NE2 GLN A  50       4.834  10.523  -0.092  1.00136.38           N  
+ATOM    414  N   GLU A  51       8.819  14.289  -1.241  1.00153.65           N  
+ATOM    415  CA  GLU A  51       8.366  15.616  -1.643  1.00152.61           C  
+ATOM    416  C   GLU A  51       8.046  15.666  -3.134  1.00151.11           C  
+ATOM    417  O   GLU A  51       7.072  16.296  -3.547  1.00156.37           O  
+ATOM    418  CB  GLU A  51       9.421  16.670  -1.296  1.00136.64           C  
+ATOM    419  N   VAL A  52       8.881  15.011  -3.937  1.00149.98           N  
+ATOM    420  CA  VAL A  52       8.671  14.948  -5.380  1.00153.44           C  
+ATOM    421  C   VAL A  52       7.337  14.293  -5.749  1.00150.72           C  
+ATOM    422  O   VAL A  52       6.568  14.840  -6.537  1.00152.44           O  
+ATOM    423  CB  VAL A  52       9.816  14.177  -6.072  1.00155.99           C  
+ATOM    424  CG1 VAL A  52       9.500  13.951  -7.543  1.00153.35           C  
+ATOM    425  CG2 VAL A  52      11.131  14.925  -5.914  1.00158.55           C  
+ATOM    426  N   VAL A  53       7.066  13.130  -5.162  1.00145.30           N  
+ATOM    427  CA  VAL A  53       5.857  12.361  -5.466  1.00138.79           C  
+ATOM    428  C   VAL A  53       4.584  13.064  -4.985  1.00144.33           C  
+ATOM    429  O   VAL A  53       3.525  12.948  -5.605  1.00149.51           O  
+ATOM    430  CB  VAL A  53       5.936  10.924  -4.865  1.00130.57           C  
+ATOM    431  CG1 VAL A  53       7.295  10.682  -4.232  1.00134.88           C  
+ATOM    432  CG2 VAL A  53       4.818  10.664  -3.857  1.00122.59           C  
+ATOM    433  N   ASP A  54       4.701  13.798  -3.883  1.00142.65           N  
+ATOM    434  CA  ASP A  54       3.616  14.628  -3.366  1.00148.49           C  
+ATOM    435  C   ASP A  54       3.148  15.689  -4.362  1.00153.97           C  
+ATOM    436  O   ASP A  54       1.948  15.876  -4.565  1.00161.13           O  
+ATOM    437  CB  ASP A  54       4.049  15.289  -2.058  1.00162.21           C  
+ATOM    438  CG  ASP A  54       3.931  14.353  -0.870  1.00155.85           C  
+ATOM    439  OD1 ASP A  54       2.914  13.635  -0.776  1.00151.14           O1-
+ATOM    440  OD2 ASP A  54       4.860  14.327  -0.036  1.00148.95           O1-
+ATOM    441  N   LYS A  55       4.101  16.381  -4.974  1.00152.67           N  
+ATOM    442  CA  LYS A  55       3.805  17.505  -5.857  1.00151.07           C  
+ATOM    443  C   LYS A  55       3.218  17.027  -7.183  1.00151.45           C  
+ATOM    444  O   LYS A  55       2.294  17.637  -7.720  1.00155.41           O  
+ATOM    445  CB  LYS A  55       5.066  18.335  -6.107  1.00141.17           C  
+ATOM    446  N   VAL A  56       3.760  15.928  -7.696  1.00152.08           N  
+ATOM    447  CA  VAL A  56       3.282  15.301  -8.927  1.00150.79           C  
+ATOM    448  C   VAL A  56       1.832  14.814  -8.862  1.00146.15           C  
+ATOM    449  O   VAL A  56       1.050  15.066  -9.780  1.00150.27           O  
+ATOM    450  CB  VAL A  56       4.180  14.106  -9.317  1.00140.65           C  
+ATOM    451  CG1 VAL A  56       3.623  13.389 -10.536  1.00140.03           C  
+ATOM    452  CG2 VAL A  56       5.603  14.575  -9.572  1.00144.08           C  
+ATOM    453  N   MET A  57       1.470  14.131  -7.781  1.00136.93           N  
+ATOM    454  CA  MET A  57       0.104  13.637  -7.619  1.00134.80           C  
+ATOM    455  C   MET A  57      -0.902  14.788  -7.566  1.00143.39           C  
+ATOM    456  O   MET A  57      -2.001  14.685  -8.110  1.00143.54           O  
+ATOM    457  CB  MET A  57      -0.004  12.780  -6.355  1.00135.55           C  
+ATOM    458  CG  MET A  57      -1.404  12.265  -6.070  1.00152.22           C  
+ATOM    459  SD  MET A  57      -1.949  11.055  -7.290  1.00144.54           S  
+ATOM    460  CE  MET A  57      -0.901   9.661  -6.879  1.00127.18           C  
+ATOM    461  N   GLU A  58      -0.518  15.879  -6.910  1.00143.53           N  
+ATOM    462  CA  GLU A  58      -1.355  17.073  -6.815  1.00142.51           C  
+ATOM    463  C   GLU A  58      -1.668  17.654  -8.196  1.00151.85           C  
+ATOM    464  O   GLU A  58      -2.801  18.046  -8.477  1.00162.08           O  
+ATOM    465  CB  GLU A  58      -0.679  18.132  -5.942  1.00125.70           C  
+ATOM    466  N   THR A  59      -0.649  17.702  -9.049  1.00151.41           N  
+ATOM    467  CA  THR A  59      -0.765  18.224 -10.411  1.00151.02           C  
+ATOM    468  C   THR A  59      -1.556  17.302 -11.340  1.00149.07           C  
+ATOM    469  O   THR A  59      -2.247  17.769 -12.246  1.00139.67           O  
+ATOM    470  CB  THR A  59       0.622  18.478 -11.030  1.00147.00           C  
+ATOM    471  OG1 THR A  59       1.346  17.244 -11.104  1.00145.71           O  
+ATOM    472  CG2 THR A  59       1.408  19.468 -10.186  1.00140.20           C  
+ATOM    473  N   LEU A  60      -1.448  15.997 -11.116  1.00143.96           N  
+ATOM    474  CA  LEU A  60      -2.105  15.005 -11.964  1.00139.19           C  
+ATOM    475  C   LEU A  60      -3.595  14.926 -11.644  1.00153.10           C  
+ATOM    476  O   LEU A  60      -4.415  14.626 -12.511  1.00158.14           O  
+ATOM    477  CB  LEU A  60      -1.461  13.627 -11.784  1.00128.46           C  
+ATOM    478  CG  LEU A  60      -0.383  13.182 -12.776  1.00125.33           C  
+ATOM    479  CD1 LEU A  60       0.645  14.278 -13.009  1.00129.25           C  
+ATOM    480  CD2 LEU A  60       0.287  11.904 -12.290  1.00106.04           C  
+ATOM    481  N   ASP A  61      -3.931  15.205 -10.390  1.00152.93           N  
+ATOM    482  CA  ASP A  61      -5.285  15.043  -9.871  1.00150.53           C  
+ATOM    483  C   ASP A  61      -6.182  16.238 -10.193  1.00158.55           C  
+ATOM    484  O   ASP A  61      -6.022  17.319  -9.626  1.00162.73           O  
+ATOM    485  CB  ASP A  61      -5.248  14.818  -8.359  1.00145.78           C  
+ATOM    486  CG  ASP A  61      -6.571  14.327  -7.812  1.00156.22           C  
+ATOM    487  OD1 ASP A  61      -7.361  13.753  -8.591  1.00160.25           O  
+ATOM    488  OD2 ASP A  61      -6.823  14.515  -6.604  1.00160.37           O1-
+ATOM    489  N   ASN A  62      -7.124  16.036 -11.110  1.00156.33           N  
+ATOM    490  CA  ASN A  62      -7.987  17.116 -11.572  1.00151.49           C  
+ATOM    491  C   ASN A  62      -9.375  16.988 -10.954  1.00166.10           C  
+ATOM    492  O   ASN A  62     -10.121  17.964 -10.879  1.00162.94           O  
+ATOM    493  CB  ASN A  62      -8.084  17.105 -13.102  1.00147.33           C  
+ATOM    494  CG  ASN A  62      -8.901  18.263 -13.651  1.00147.06           C  
+ATOM    495  OD1 ASN A  62      -8.981  19.329 -13.041  1.00146.41           O  
+ATOM    496  ND2 ASN A  62      -9.511  18.057 -14.814  1.00141.90           N  
+ATOM    497  N   ASP A  63      -9.717  15.785 -10.501  1.00177.08           N  
+ATOM    498  CA  ASP A  63     -11.007  15.567  -9.857  1.00171.67           C  
+ATOM    499  C   ASP A  63     -10.862  15.714  -8.342  1.00171.96           C  
+ATOM    500  O   ASP A  63     -11.844  15.660  -7.602  1.00173.81           O  
+ATOM    501  CB  ASP A  63     -11.577  14.191 -10.217  1.00165.94           C  
+ATOM    502  CG  ASP A  63     -10.693  13.046  -9.755  1.00170.60           C  
+ATOM    503  OD1 ASP A  63      -9.513  13.286  -9.418  1.00178.31           O  
+ATOM    504  OD2 ASP A  63     -11.183  11.897  -9.727  1.00161.33           O1-
+ATOM    505  N   GLY A  64      -9.623  15.904  -7.897  1.00167.67           N  
+ATOM    506  CA  GLY A  64      -9.321  16.208  -6.509  1.00165.86           C  
+ATOM    507  C   GLY A  64      -9.613  15.144  -5.463  1.00169.15           C  
+ATOM    508  O   GLY A  64     -10.222  15.448  -4.437  1.00172.12           O  
+ATOM    509  N   ASP A  65      -9.184  13.905  -5.697  1.00168.21           N  
+ATOM    510  CA  ASP A  65      -9.369  12.857  -4.692  1.00160.35           C  
+ATOM    511  C   ASP A  65      -8.043  12.298  -4.167  1.00153.75           C  
+ATOM    512  O   ASP A  65      -8.023  11.381  -3.347  1.00150.63           O  
+ATOM    513  CB  ASP A  65     -10.231  11.724  -5.259  1.00168.07           C  
+ATOM    514  CG  ASP A  65      -9.582  11.022  -6.440  1.00164.62           C  
+ATOM    515  OD1 ASP A  65      -8.487  11.442  -6.866  1.00164.28           O  
+ATOM    516  OD2 ASP A  65     -10.172  10.044  -6.944  1.00160.54           O1-
+ATOM    517  N   GLY A  66      -6.943  12.861  -4.653  1.00155.58           N  
+ATOM    518  CA  GLY A  66      -5.607  12.501  -4.212  1.00156.79           C  
+ATOM    519  C   GLY A  66      -4.995  11.227  -4.771  1.00159.65           C  
+ATOM    520  O   GLY A  66      -3.993  10.744  -4.244  1.00160.75           O  
+ATOM    521  N   GLU A  67      -5.578  10.682  -5.836  1.00160.12           N  
+ATOM    522  CA  GLU A  67      -5.058   9.455  -6.440  1.00152.83           C  
+ATOM    523  C   GLU A  67      -5.204   9.534  -7.954  1.00150.84           C  
+ATOM    524  O   GLU A  67      -5.939  10.379  -8.466  1.00147.57           O  
+ATOM    525  CB  GLU A  67      -5.770   8.209  -5.901  1.00142.45           C  
+ATOM    526  CG  GLU A  67      -5.564   7.944  -4.417  1.00145.03           C  
+ATOM    527  CD  GLU A  67      -6.084   6.585  -3.991  1.00148.79           C  
+ATOM    528  OE1 GLU A  67      -6.843   6.524  -3.002  1.00154.25           O  
+ATOM    529  OE2 GLU A  67      -5.722   5.578  -4.636  1.00131.71           O1-
+ATOM    530  N   CYS A  68      -4.508   8.659  -8.672  1.00145.20           N  
+ATOM    531  CA  CYS A  68      -4.571   8.690 -10.128  1.00145.49           C  
+ATOM    532  C   CYS A  68      -5.353   7.532 -10.747  1.00133.14           C  
+ATOM    533  O   CYS A  68      -4.898   6.388 -10.721  1.00131.36           O  
+ATOM    534  CB  CYS A  68      -3.152   8.708 -10.698  1.00137.92           C  
+ATOM    535  SG  CYS A  68      -3.067   8.684 -12.497  1.00144.58           S  
+ATOM    536  N   ASP A  69      -6.527   7.827 -11.297  1.00120.96           N  
+ATOM    537  CA  ASP A  69      -7.310   6.817 -12.000  1.00110.16           C  
+ATOM    538  C   ASP A  69      -6.792   6.747 -13.434  1.00111.26           C  
+ATOM    539  O   ASP A  69      -5.849   7.457 -13.785  1.00108.05           O  
+ATOM    540  CB  ASP A  69      -8.807   7.131 -11.959  1.00114.34           C  
+ATOM    541  CG  ASP A  69      -9.181   8.320 -12.814  1.00118.89           C  
+ATOM    542  OD1 ASP A  69      -8.899   9.464 -12.405  1.00124.85           O1-
+ATOM    543  OD2 ASP A  69      -9.772   8.106 -13.891  1.00119.64           O1-
+ATOM    544  N   PHE A  70      -7.394   5.899 -14.262  1.00107.42           N  
+ATOM    545  CA  PHE A  70      -6.871   5.670 -15.607  1.00 92.67           C  
+ATOM    546  C   PHE A  70      -6.988   6.921 -16.471  1.00 90.56           C  
+ATOM    547  O   PHE A  70      -6.085   7.239 -17.245  1.00 85.06           O  
+ATOM    548  CB  PHE A  70      -7.595   4.514 -16.292  1.00 93.78           C  
+ATOM    549  CG  PHE A  70      -7.016   4.157 -17.631  1.00 84.28           C  
+ATOM    550  CD1 PHE A  70      -5.805   3.493 -17.723  1.00 82.21           C  
+ATOM    551  CD2 PHE A  70      -7.673   4.508 -18.799  1.00 82.93           C  
+ATOM    552  CE1 PHE A  70      -5.266   3.173 -18.954  1.00 79.66           C  
+ATOM    553  CE2 PHE A  70      -7.140   4.191 -20.033  1.00 80.80           C  
+ATOM    554  CZ  PHE A  70      -5.935   3.522 -20.111  1.00 75.94           C  
+ATOM    555  N   GLN A  71      -8.113   7.614 -16.336  1.00 98.95           N  
+ATOM    556  CA  GLN A  71      -8.381   8.824 -17.102  1.00 91.71           C  
+ATOM    557  C   GLN A  71      -7.312   9.885 -16.843  1.00 99.28           C  
+ATOM    558  O   GLN A  71      -6.808  10.516 -17.773  1.00 95.17           O  
+ATOM    559  CB  GLN A  71      -9.771   9.344 -16.736  1.00 88.64           C  
+ATOM    560  CG  GLN A  71     -10.279  10.513 -17.534  1.00120.09           C  
+ATOM    561  CD  GLN A  71     -11.755  10.752 -17.284  1.00148.54           C  
+ATOM    562  OE1 GLN A  71     -12.163  11.848 -16.900  1.00164.90           O  
+ATOM    563  NE2 GLN A  71     -12.566   9.723 -17.502  1.00140.42           N  
+ATOM    564  N   GLU A  72      -6.978  10.075 -15.571  1.00102.79           N  
+ATOM    565  CA  GLU A  72      -5.945  11.021 -15.156  1.00109.74           C  
+ATOM    566  C   GLU A  72      -4.560  10.562 -15.601  1.00 99.58           C  
+ATOM    567  O   GLU A  72      -3.692  11.373 -15.924  1.00 94.48           O  
+ATOM    568  CB  GLU A  72      -5.962  11.234 -13.641  1.00130.22           C  
+ATOM    569  CG  GLU A  72      -7.133  12.068 -13.148  1.00148.96           C  
+ATOM    570  CD  GLU A  72      -7.415  11.865 -11.674  1.00162.03           C  
+ATOM    571  OE1 GLU A  72      -7.112  10.772 -11.151  1.00156.00           O  
+ATOM    572  OE2 GLU A  72      -7.940  12.803 -11.037  1.00173.72           O1-
+ATOM    573  N   PHE A  73      -4.371   9.247 -15.608  1.00101.83           N  
+ATOM    574  CA  PHE A  73      -3.134   8.625 -16.069  1.00 95.69           C  
+ATOM    575  C   PHE A  73      -2.887   8.823 -17.561  1.00 85.34           C  
+ATOM    576  O   PHE A  73      -1.744   9.019 -17.974  1.00 77.78           O  
+ATOM    577  CB  PHE A  73      -3.166   7.130 -15.728  1.00 92.54           C  
+ATOM    578  CG  PHE A  73      -2.047   6.333 -16.335  1.00 76.44           C  
+ATOM    579  CD1 PHE A  73      -0.759   6.431 -15.837  1.00 71.82           C  
+ATOM    580  CD2 PHE A  73      -2.290   5.461 -17.384  1.00 84.48           C  
+ATOM    581  CE1 PHE A  73       0.270   5.690 -16.386  1.00 70.63           C  
+ATOM    582  CE2 PHE A  73      -1.265   4.717 -17.937  1.00 79.37           C  
+ATOM    583  CZ  PHE A  73       0.017   4.830 -17.436  1.00 72.86           C  
+ATOM    584  N   MET A  74      -3.941   8.773 -18.369  1.00 74.15           N  
+ATOM    585  CA  MET A  74      -3.783   9.018 -19.799  1.00 70.88           C  
+ATOM    586  C   MET A  74      -3.322  10.444 -20.064  1.00 68.78           C  
+ATOM    587  O   MET A  74      -2.520  10.685 -20.966  1.00 66.06           O  
+ATOM    588  CB  MET A  74      -5.085   8.743 -20.552  1.00 67.09           C  
+ATOM    589  CG  MET A  74      -5.367   7.272 -20.773  1.00 80.55           C  
+ATOM    590  SD  MET A  74      -3.965   6.439 -21.544  1.00 79.76           S  
+ATOM    591  CE  MET A  74      -3.780   7.384 -23.054  1.00 58.79           C  
+ATOM    592  N   ALA A  75      -3.836  11.388 -19.281  1.00 74.09           N  
+ATOM    593  CA  ALA A  75      -3.378  12.768 -19.364  1.00 75.06           C  
+ATOM    594  C   ALA A  75      -1.886  12.848 -19.072  1.00 75.66           C  
+ATOM    595  O   ALA A  75      -1.146  13.545 -19.766  1.00 73.87           O  
+ATOM    596  CB  ALA A  75      -4.159  13.649 -18.403  1.00 86.14           C  
+ATOM    597  N   PHE A  76      -1.455  12.139 -18.032  1.00 84.19           N  
+ATOM    598  CA  PHE A  76      -0.043  12.079 -17.675  1.00 71.51           C  
+ATOM    599  C   PHE A  76       0.814  11.508 -18.802  1.00 70.76           C  
+ATOM    600  O   PHE A  76       1.833  12.092 -19.174  1.00 60.17           O  
+ATOM    601  CB  PHE A  76       0.132  11.241 -16.403  1.00 80.91           C  
+ATOM    602  CG  PHE A  76       1.565  10.989 -16.025  1.00 87.63           C  
+ATOM    603  CD1 PHE A  76       2.400  12.037 -15.671  1.00 90.35           C  
+ATOM    604  CD2 PHE A  76       2.074   9.700 -16.012  1.00 79.30           C  
+ATOM    605  CE1 PHE A  76       3.718  11.803 -15.318  1.00 70.39           C  
+ATOM    606  CE2 PHE A  76       3.391   9.461 -15.660  1.00 68.89           C  
+ATOM    607  CZ  PHE A  76       4.214  10.514 -15.313  1.00 60.62           C  
+ATOM    608  N   VAL A  77       0.398  10.362 -19.336  1.00 80.93           N  
+ATOM    609  CA  VAL A  77       1.070   9.748 -20.479  1.00 74.30           C  
+ATOM    610  C   VAL A  77       1.144  10.677 -21.691  1.00 72.18           C  
+ATOM    611  O   VAL A  77       2.187  10.790 -22.338  1.00 65.01           O  
+ATOM    612  CB  VAL A  77       0.369   8.436 -20.887  1.00 76.87           C  
+ATOM    613  CG1 VAL A  77       0.914   7.921 -22.210  1.00 62.71           C  
+ATOM    614  CG2 VAL A  77       0.538   7.392 -19.796  1.00 65.81           C  
+ATOM    615  N   ALA A  78       0.029  11.347 -21.980  1.00 68.99           N  
+ATOM    616  CA  ALA A  78      -0.043  12.333 -23.057  1.00 59.66           C  
+ATOM    617  C   ALA A  78       0.985  13.434 -22.858  1.00 71.08           C  
+ATOM    618  O   ALA A  78       1.670  13.852 -23.791  1.00 71.58           O  
+ATOM    619  CB  ALA A  78      -1.441  12.921 -23.146  1.00 65.06           C  
+ATOM    620  N   MET A  79       1.068  13.896 -21.617  1.00 73.07           N  
+ATOM    621  CA  MET A  79       1.921  15.008 -21.230  1.00 64.99           C  
+ATOM    622  C   MET A  79       3.392  14.643 -21.401  1.00 72.00           C  
+ATOM    623  O   MET A  79       4.158  15.377 -22.024  1.00 77.28           O  
+ATOM    624  CB  MET A  79       1.616  15.419 -19.789  1.00 87.75           C  
+ATOM    625  CG  MET A  79       2.148  16.781 -19.386  1.00 97.52           C  
+ATOM    626  SD  MET A  79       1.916  17.088 -17.624  1.00103.94           S  
+ATOM    627  CE  MET A  79       0.353  16.259 -17.333  1.00 88.31           C  
+ATOM    628  N   VAL A  80       3.771  13.500 -20.838  1.00 66.05           N  
+ATOM    629  CA  VAL A  80       5.137  12.991 -20.923  1.00 60.87           C  
+ATOM    630  C   VAL A  80       5.584  12.740 -22.366  1.00 63.67           C  
+ATOM    631  O   VAL A  80       6.688  13.125 -22.757  1.00 60.90           O  
+ATOM    632  CB  VAL A  80       5.284  11.683 -20.117  1.00 70.85           C  
+ATOM    633  CG1 VAL A  80       6.629  11.029 -20.392  1.00 79.45           C  
+ATOM    634  CG2 VAL A  80       5.121  11.958 -18.631  1.00 80.65           C  
+ATOM    635  N   THR A  81       4.717  12.113 -23.156  1.00 69.47           N  
+ATOM    636  CA  THR A  81       5.024  11.772 -24.545  1.00 51.67           C  
+ATOM    637  C   THR A  81       5.274  13.017 -25.400  1.00 54.65           C  
+ATOM    638  O   THR A  81       6.215  13.054 -26.195  1.00 54.20           O  
+ATOM    639  CB  THR A  81       3.893  10.943 -25.180  1.00 39.88           C  
+ATOM    640  OG1 THR A  81       3.595   9.819 -24.343  1.00 53.36           O  
+ATOM    641  CG2 THR A  81       4.303  10.444 -26.553  1.00 41.68           C  
+ATOM    642  N   THR A  82       4.424  14.025 -25.232  1.00 61.94           N  
+ATOM    643  CA  THR A  82       4.537  15.289 -25.960  1.00 67.07           C  
+ATOM    644  C   THR A  82       5.908  15.926 -25.734  1.00 68.43           C  
+ATOM    645  O   THR A  82       6.556  16.390 -26.674  1.00 86.40           O  
+ATOM    646  CB  THR A  82       3.435  16.280 -25.540  1.00 62.90           C  
+ATOM    647  OG1 THR A  82       2.164  15.807 -26.002  1.00 60.95           O  
+ATOM    648  CG2 THR A  82       3.699  17.659 -26.125  1.00 77.67           C  
+ATOM    649  N   ALA A  83       6.340  15.932 -24.478  1.00 69.86           N  
+ATOM    650  CA  ALA A  83       7.631  16.486 -24.080  1.00 78.84           C  
+ATOM    651  C   ALA A  83       8.781  15.773 -24.791  1.00 75.93           C  
+ATOM    652  O   ALA A  83       9.735  16.410 -25.239  1.00 92.28           O  
+ATOM    653  CB  ALA A  83       7.804  16.393 -22.574  1.00 93.87           C  
+ATOM    654  N   CYS A  84       8.677  14.453 -24.895  1.00 68.84           N  
+ATOM    655  CA  CYS A  84       9.682  13.646 -25.582  1.00 75.05           C  
+ATOM    656  C   CYS A  84       9.718  13.948 -27.079  1.00 82.09           C  
+ATOM    657  O   CYS A  84      10.778  13.904 -27.697  1.00 85.57           O  
+ATOM    658  CB  CYS A  84       9.415  12.157 -25.357  1.00 76.24           C  
+ATOM    659  SG  CYS A  84       9.439  11.643 -23.624  1.00 97.83           S  
+ATOM    660  N   HIS A  85       8.564  14.287 -27.646  1.00 77.04           N  
+ATOM    661  CA  HIS A  85       8.458  14.622 -29.064  1.00 69.37           C  
+ATOM    662  C   HIS A  85       9.229  15.920 -29.309  1.00 76.83           C  
+ATOM    663  O   HIS A  85      10.039  16.014 -30.232  1.00 91.63           O  
+ATOM    664  CB  HIS A  85       6.990  14.755 -29.478  1.00 64.98           C  
+ATOM    665  CG  HIS A  85       6.795  15.135 -30.913  1.00 64.89           C  
+ATOM    666  ND1 HIS A  85       6.492  16.419 -31.309  1.00 74.48           N  
+ATOM    667  CD2 HIS A  85       6.847  14.394 -32.045  1.00 55.67           C  
+ATOM    668  CE1 HIS A  85       6.373  16.456 -32.624  1.00 75.58           C  
+ATOM    669  NE2 HIS A  85       6.584  15.240 -33.095  1.00 67.04           N  
+ATOM    670  N   GLU A  86       8.957  16.913 -28.471  1.00 67.28           N  
+ATOM    671  CA  GLU A  86       9.557  18.245 -28.542  1.00 88.27           C  
+ATOM    672  C   GLU A  86      11.088  18.188 -28.435  1.00 98.69           C  
+ATOM    673  O   GLU A  86      11.801  18.984 -29.046  1.00101.27           O  
+ATOM    674  CB  GLU A  86       8.987  19.144 -27.443  1.00 75.80           C  
+ATOM    675  N   PHE A  87      11.571  17.229 -27.652  1.00 95.64           N  
+ATOM    676  CA  PHE A  87      12.997  16.969 -27.431  1.00 95.64           C  
+ATOM    677  C   PHE A  87      13.586  15.941 -28.408  1.00 91.42           C  
+ATOM    678  O   PHE A  87      14.490  15.185 -28.066  1.00101.67           O  
+ATOM    679  CB  PHE A  87      13.264  16.527 -25.989  1.00102.33           C  
+ATOM    680  CG  PHE A  87      14.724  16.551 -25.625  1.00126.97           C  
+ATOM    681  CD1 PHE A  87      15.463  17.712 -25.784  1.00132.17           C  
+ATOM    682  CD2 PHE A  87      15.363  15.412 -25.165  1.00110.56           C  
+ATOM    683  CE1 PHE A  87      16.805  17.743 -25.474  1.00133.75           C  
+ATOM    684  CE2 PHE A  87      16.708  15.439 -24.853  1.00120.08           C  
+ATOM    685  CZ  PHE A  87      17.428  16.606 -25.012  1.00131.61           C  
+ATOM    686  N   PHE A  88      13.093  15.960 -29.641  1.00 89.52           N  
+ATOM    687  CA  PHE A  88      13.569  15.071 -30.699  1.00 87.79           C  
+ATOM    688  C   PHE A  88      13.587  15.868 -31.995  1.00 94.37           C  
+ATOM    689  O   PHE A  88      14.168  15.443 -32.992  1.00107.24           O  
+ATOM    690  CB  PHE A  88      12.663  13.843 -30.869  1.00 95.64           C  
+ATOM    691  CG  PHE A  88      12.901  12.745 -29.867  1.00 96.07           C  
+ATOM    692  CD1 PHE A  88      14.135  12.578 -29.265  1.00 97.86           C  
+ATOM    693  CD2 PHE A  88      11.883  11.860 -29.549  1.00 86.57           C  
+ATOM    694  CE1 PHE A  88      14.343  11.565 -28.346  1.00 95.44           C  
+ATOM    695  CE2 PHE A  88      12.085  10.846 -28.633  1.00 82.48           C  
+ATOM    696  CZ  PHE A  88      13.316  10.697 -28.032  1.00 86.00           C  
+ATOM    697  N   GLU A  89      12.946  17.030 -31.969  1.00100.49           N  
+ATOM    698  CA  GLU A  89      12.890  17.908 -33.130  1.00103.69           C  
+ATOM    699  C   GLU A  89      13.312  19.307 -32.695  1.00112.66           C  
+ATOM    700  O   GLU A  89      12.923  20.309 -33.297  1.00124.50           O  
+ATOM    701  CB  GLU A  89      11.501  17.912 -33.764  1.00101.89           C  
+ATOM    702  CG  GLU A  89      11.258  16.710 -34.659  1.00 99.99           C  
+ATOM    703  CD  GLU A  89       9.911  16.064 -34.431  1.00 89.23           C  
+ATOM    704  OE1 GLU A  89       8.919  16.798 -34.245  1.00 83.28           O  
+ATOM    705  OE2 GLU A  89       9.847  14.816 -34.435  1.00 86.36           O1-
+ATOM    706  N   HIS A  90      14.122  19.354 -31.640  1.00113.04           N  
+ATOM    707  CA  HIS A  90      14.693  20.600 -31.142  1.00116.99           C  
+ATOM    708  C   HIS A  90      16.075  20.361 -30.539  1.00103.68           C  
+ATOM    709  O   HIS A  90      16.358  19.284 -30.012  1.00100.33           O  
+ATOM    710  CB  HIS A  90      13.771  21.243 -30.105  1.00 91.17           C  
+TER     711      HIS A  90                                                      
+ATOM    712  N   SER B  -2      17.351  -2.518 -16.490  1.00115.47           N  
+ATOM    713  CA  SER B  -2      17.927  -1.533 -17.396  1.00131.99           C  
+ATOM    714  C   SER B  -2      17.798  -1.978 -18.851  1.00131.40           C  
+ATOM    715  O   SER B  -2      18.747  -2.486 -19.449  1.00127.69           O  
+ATOM    716  CB  SER B  -2      19.392  -1.275 -17.046  1.00126.09           C  
+ATOM    717  N   HIS B  -1      16.598  -1.790 -19.389  1.00135.18           N  
+ATOM    718  CA  HIS B  -1      16.263  -2.012 -20.794  1.00131.84           C  
+ATOM    719  C   HIS B  -1      14.839  -1.492 -20.903  1.00132.30           C  
+ATOM    720  O   HIS B  -1      13.929  -2.057 -20.292  1.00139.00           O  
+ATOM    721  CB  HIS B  -1      16.377  -3.488 -21.185  1.00136.69           C  
+ATOM    722  CG  HIS B  -1      16.312  -3.735 -22.661  1.00130.46           C  
+ATOM    723  ND1 HIS B  -1      16.051  -2.739 -23.576  1.00130.33           N  
+ATOM    724  CD2 HIS B  -1      16.474  -4.872 -23.379  1.00133.02           C  
+ATOM    725  CE1 HIS B  -1      16.054  -3.251 -24.794  1.00137.53           C  
+ATOM    726  NE2 HIS B  -1      16.308  -4.544 -24.702  1.00139.77           N  
+ATOM    727  N   MET B   0      14.676  -0.404 -21.658  1.00122.52           N  
+ATOM    728  CA  MET B   0      13.389   0.143 -22.111  1.00110.65           C  
+ATOM    729  C   MET B   0      12.147  -0.711 -21.862  1.00105.86           C  
+ATOM    730  O   MET B   0      12.058  -1.868 -22.288  1.00103.23           O  
+ATOM    731  CB  MET B   0      13.481   0.435 -23.613  1.00102.09           C  
+ATOM    732  CG  MET B   0      12.823   1.732 -24.065  1.00102.36           C  
+ATOM    733  SD  MET B   0      14.001   3.086 -24.258  1.00135.41           S  
+ATOM    734  CE  MET B   0      13.018   4.262 -25.187  1.00100.14           C  
+ATOM    735  N   SER B   1      11.180  -0.103 -21.183  1.00 93.78           N  
+ATOM    736  CA  SER B   1       9.941  -0.780 -20.817  1.00 84.94           C  
+ATOM    737  C   SER B   1       8.936  -0.865 -21.956  1.00 89.63           C  
+ATOM    738  O   SER B   1       9.078  -0.194 -22.976  1.00 94.96           O  
+ATOM    739  CB  SER B   1       9.295  -0.088 -19.616  1.00 79.66           C  
+ATOM    740  OG  SER B   1       8.910   1.235 -19.928  1.00 79.64           O  
+ATOM    741  N   GLU B   2       7.912  -1.683 -21.754  1.00 87.95           N  
+ATOM    742  CA  GLU B   2       6.782  -1.756 -22.662  1.00 84.97           C  
+ATOM    743  C   GLU B   2       6.105  -0.388 -22.762  1.00 73.75           C  
+ATOM    744  O   GLU B   2       5.705   0.046 -23.843  1.00 80.14           O  
+ATOM    745  CB  GLU B   2       5.782  -2.827 -22.194  1.00 97.52           C  
+ATOM    746  CG  GLU B   2       6.324  -4.249 -22.165  1.00 92.52           C  
+ATOM    747  CD  GLU B   2       6.343  -4.862 -23.545  1.00 92.81           C  
+ATOM    748  OE1 GLU B   2       5.624  -4.342 -24.416  1.00 88.23           O  
+ATOM    749  OE2 GLU B   2       7.039  -5.869 -23.766  1.00111.92           O1-
+ATOM    750  N   LEU B   3       5.951   0.261 -21.610  1.00 69.96           N  
+ATOM    751  CA  LEU B   3       5.402   1.613 -21.525  1.00 61.10           C  
+ATOM    752  C   LEU B   3       6.212   2.583 -22.377  1.00 79.88           C  
+ATOM    753  O   LEU B   3       5.648   3.383 -23.123  1.00 85.88           O  
+ATOM    754  CB  LEU B   3       5.364   2.084 -20.071  1.00 65.72           C  
+ATOM    755  CG  LEU B   3       4.839   3.493 -19.783  1.00 73.77           C  
+ATOM    756  CD1 LEU B   3       3.538   3.760 -20.528  1.00 57.67           C  
+ATOM    757  CD2 LEU B   3       4.638   3.676 -18.290  1.00 70.29           C  
+ATOM    758  N   GLU B   4       7.534   2.518 -22.251  1.00 83.15           N  
+ATOM    759  CA  GLU B   4       8.395   3.467 -22.938  1.00 78.51           C  
+ATOM    760  C   GLU B   4       8.373   3.200 -24.436  1.00 80.80           C  
+ATOM    761  O   GLU B   4       8.497   4.125 -25.232  1.00 75.09           O  
+ATOM    762  CB  GLU B   4       9.829   3.408 -22.405  1.00 95.20           C  
+ATOM    763  CG  GLU B   4      10.003   4.015 -21.019  1.00 99.21           C  
+ATOM    764  CD  GLU B   4      11.363   3.721 -20.406  1.00103.19           C  
+ATOM    765  OE1 GLU B   4      11.878   2.598 -20.591  1.00104.48           O  
+ATOM    766  OE2 GLU B   4      11.917   4.617 -19.733  1.00100.36           O1-
+ATOM    767  N   LYS B   5       8.200   1.938 -24.819  1.00 75.77           N  
+ATOM    768  CA  LYS B   5       8.124   1.586 -26.234  1.00 71.74           C  
+ATOM    769  C   LYS B   5       6.742   1.906 -26.786  1.00 61.46           C  
+ATOM    770  O   LYS B   5       6.579   2.118 -27.986  1.00 62.27           O  
+ATOM    771  CB  LYS B   5       8.443   0.103 -26.461  1.00 82.68           C  
+ATOM    772  CG  LYS B   5       9.818  -0.338 -25.986  1.00 75.55           C  
+ATOM    773  CD  LYS B   5      10.201  -1.697 -26.564  1.00 76.51           C  
+ATOM    774  CE  LYS B   5      10.421  -2.740 -25.477  1.00 95.26           C  
+ATOM    775  NZ  LYS B   5       9.179  -3.488 -25.136  1.00 75.16           N1+
+ATOM    776  N   ALA B   6       5.749   1.940 -25.902  1.00 70.11           N  
+ATOM    777  CA  ALA B   6       4.409   2.373 -26.278  1.00 59.85           C  
+ATOM    778  C   ALA B   6       4.381   3.844 -26.682  1.00 62.06           C  
+ATOM    779  O   ALA B   6       3.835   4.194 -27.728  1.00 71.07           O  
+ATOM    780  CB  ALA B   6       3.435   2.122 -25.136  1.00 54.47           C  
+ATOM    781  N   MET B   7       4.970   4.697 -25.849  1.00 53.75           N  
+ATOM    782  CA  MET B   7       5.033   6.130 -26.121  1.00 59.46           C  
+ATOM    783  C   MET B   7       5.725   6.426 -27.452  1.00 53.41           C  
+ATOM    784  O   MET B   7       5.237   7.225 -28.253  1.00 62.29           O  
+ATOM    785  CB  MET B   7       5.752   6.854 -24.982  1.00 73.70           C  
+ATOM    786  CG  MET B   7       4.970   6.887 -23.679  1.00 55.94           C  
+ATOM    787  SD  MET B   7       5.914   7.617 -22.330  1.00 80.66           S  
+ATOM    788  CE  MET B   7       4.617   7.934 -21.135  1.00 95.75           C  
+ATOM    789  N   VAL B   8       6.866   5.780 -27.669  1.00 57.34           N  
+ATOM    790  CA  VAL B   8       7.619   5.896 -28.915  1.00 51.43           C  
+ATOM    791  C   VAL B   8       6.773   5.509 -30.126  1.00 57.85           C  
+ATOM    792  O   VAL B   8       6.840   6.153 -31.174  1.00 74.07           O  
+ATOM    793  CB  VAL B   8       8.896   5.032 -28.886  1.00 61.84           C  
+ATOM    794  CG1 VAL B   8       9.660   5.163 -30.191  1.00 76.74           C  
+ATOM    795  CG2 VAL B   8       9.776   5.432 -27.715  1.00 66.60           C  
+ATOM    796  N   ALA B   9       5.961   4.469 -29.969  1.00 51.55           N  
+ATOM    797  CA  ALA B   9       5.158   3.952 -31.070  1.00 40.67           C  
+ATOM    798  C   ALA B   9       4.102   4.969 -31.478  1.00 58.60           C  
+ATOM    799  O   ALA B   9       3.748   5.067 -32.653  1.00 63.57           O  
+ATOM    800  CB  ALA B   9       4.509   2.635 -30.685  1.00 44.43           C  
+ATOM    801  N   LEU B  10       3.598   5.719 -30.501  1.00 61.52           N  
+ATOM    802  CA  LEU B  10       2.626   6.774 -30.765  1.00 45.76           C  
+ATOM    803  C   LEU B  10       3.267   7.837 -31.651  1.00 51.49           C  
+ATOM    804  O   LEU B  10       2.651   8.333 -32.594  1.00 52.26           O  
+ATOM    805  CB  LEU B  10       2.123   7.393 -29.461  1.00 39.72           C  
+ATOM    806  CG  LEU B  10       1.505   6.419 -28.456  1.00 45.52           C  
+ATOM    807  CD1 LEU B  10       0.885   7.167 -27.290  1.00 56.78           C  
+ATOM    808  CD2 LEU B  10       0.481   5.517 -29.125  1.00 37.09           C  
+ATOM    809  N   ILE B  11       4.506   8.190 -31.326  1.00 46.13           N  
+ATOM    810  CA  ILE B  11       5.281   9.135 -32.121  1.00 51.18           C  
+ATOM    811  C   ILE B  11       5.525   8.612 -33.537  1.00 56.39           C  
+ATOM    812  O   ILE B  11       5.406   9.359 -34.509  1.00 64.39           O  
+ATOM    813  CB  ILE B  11       6.634   9.453 -31.455  1.00 58.98           C  
+ATOM    814  CG1 ILE B  11       6.407  10.129 -30.102  1.00 53.22           C  
+ATOM    815  CG2 ILE B  11       7.474  10.353 -32.345  1.00 60.75           C  
+ATOM    816  CD1 ILE B  11       7.634  10.168 -29.224  1.00 50.18           C  
+ATOM    817  N   ASP B  12       5.848   7.327 -33.654  1.00 57.02           N  
+ATOM    818  CA  ASP B  12       6.190   6.758 -34.954  1.00 57.31           C  
+ATOM    819  C   ASP B  12       4.983   6.696 -35.880  1.00 54.82           C  
+ATOM    820  O   ASP B  12       5.085   7.050 -37.052  1.00 56.63           O  
+ATOM    821  CB  ASP B  12       6.773   5.348 -34.798  1.00 58.79           C  
+ATOM    822  CG  ASP B  12       8.122   5.339 -34.106  1.00 78.03           C  
+ATOM    823  OD1 ASP B  12       9.106   5.823 -34.703  1.00 88.93           O  
+ATOM    824  OD2 ASP B  12       8.202   4.824 -32.971  1.00 86.74           O1-
+ATOM    825  N   VAL B  13       3.837   6.282 -35.348  1.00 54.49           N  
+ATOM    826  CA  VAL B  13       2.631   6.154 -36.161  1.00 39.94           C  
+ATOM    827  C   VAL B  13       2.150   7.523 -36.640  1.00 50.14           C  
+ATOM    828  O   VAL B  13       1.580   7.642 -37.725  1.00 66.64           O  
+ATOM    829  CB  VAL B  13       1.495   5.419 -35.402  1.00 45.14           C  
+ATOM    830  CG1 VAL B  13       0.914   6.277 -34.290  1.00 58.22           C  
+ATOM    831  CG2 VAL B  13       0.407   4.978 -36.375  1.00 35.64           C  
+ATOM    832  N   PHE B  14       2.380   8.554 -35.832  1.00 48.56           N  
+ATOM    833  CA  PHE B  14       2.001   9.906 -36.213  1.00 41.48           C  
+ATOM    834  C   PHE B  14       2.842  10.343 -37.403  1.00 50.11           C  
+ATOM    835  O   PHE B  14       2.314  10.801 -38.414  1.00 58.22           O  
+ATOM    836  CB  PHE B  14       2.183  10.878 -35.044  1.00 55.94           C  
+ATOM    837  CG  PHE B  14       1.855  12.307 -35.383  1.00 55.85           C  
+ATOM    838  CD1 PHE B  14       0.537  12.733 -35.444  1.00 47.05           C  
+ATOM    839  CD2 PHE B  14       2.862  13.224 -35.639  1.00 47.30           C  
+ATOM    840  CE1 PHE B  14       0.230  14.047 -35.753  1.00 39.40           C  
+ATOM    841  CE2 PHE B  14       2.560  14.539 -35.949  1.00 55.08           C  
+ATOM    842  CZ  PHE B  14       1.242  14.950 -36.006  1.00 47.26           C  
+ATOM    843  N   HIS B  15       4.155  10.181 -37.278  1.00 51.14           N  
+ATOM    844  CA  HIS B  15       5.085  10.578 -38.327  1.00 38.55           C  
+ATOM    845  C   HIS B  15       4.956   9.700 -39.571  1.00 40.33           C  
+ATOM    846  O   HIS B  15       5.207  10.157 -40.687  1.00 49.25           O  
+ATOM    847  CB  HIS B  15       6.521  10.541 -37.803  1.00 50.23           C  
+ATOM    848  CG  HIS B  15       6.859  11.675 -36.886  1.00 63.78           C  
+ATOM    849  ND1 HIS B  15       6.910  12.986 -37.311  1.00 71.80           N  
+ATOM    850  CD2 HIS B  15       7.167  11.696 -35.568  1.00 63.03           C  
+ATOM    851  CE1 HIS B  15       7.232  13.764 -36.294  1.00 71.56           C  
+ATOM    852  NE2 HIS B  15       7.394  13.006 -35.225  1.00 81.84           N  
+ATOM    853  N   GLN B  16       4.577   8.439 -39.376  1.00 43.28           N  
+ATOM    854  CA  GLN B  16       4.330   7.539 -40.499  1.00 49.10           C  
+ATOM    855  C   GLN B  16       3.245   8.073 -41.425  1.00 44.25           C  
+ATOM    856  O   GLN B  16       3.274   7.840 -42.633  1.00 69.56           O  
+ATOM    857  CB  GLN B  16       3.915   6.148 -40.001  1.00 54.59           C  
+ATOM    858  CG  GLN B  16       5.045   5.244 -39.533  1.00 65.90           C  
+ATOM    859  CD  GLN B  16       4.540   3.897 -39.034  1.00 81.15           C  
+ATOM    860  OE1 GLN B  16       3.334   3.684 -38.899  1.00 61.02           O  
+ATOM    861  NE2 GLN B  16       5.464   2.986 -38.748  1.00 81.95           N  
+ATOM    862  N   TYR B  17       2.285   8.787 -40.847  1.00 41.80           N  
+ATOM    863  CA  TYR B  17       1.153   9.295 -41.609  1.00 43.40           C  
+ATOM    864  C   TYR B  17       1.171  10.806 -41.842  1.00 43.90           C  
+ATOM    865  O   TYR B  17       0.707  11.282 -42.875  1.00 53.28           O  
+ATOM    866  CB  TYR B  17      -0.145   8.878 -40.917  1.00 49.17           C  
+ATOM    867  CG  TYR B  17      -0.486   7.429 -41.181  1.00 51.56           C  
+ATOM    868  CD1 TYR B  17      -0.015   6.424 -40.345  1.00 39.31           C  
+ATOM    869  CD2 TYR B  17      -1.245   7.062 -42.284  1.00 57.45           C  
+ATOM    870  CE1 TYR B  17      -0.309   5.098 -40.587  1.00 38.82           C  
+ATOM    871  CE2 TYR B  17      -1.544   5.736 -42.536  1.00 53.41           C  
+ATOM    872  CZ  TYR B  17      -1.073   4.759 -41.683  1.00 41.98           C  
+ATOM    873  OH  TYR B  17      -1.364   3.439 -41.928  1.00 49.91           O  
+ATOM    874  N   SER B  18       1.703  11.561 -40.886  1.00 43.05           N  
+ATOM    875  CA  SER B  18       1.773  13.014 -41.029  1.00 46.45           C  
+ATOM    876  C   SER B  18       2.790  13.483 -42.066  1.00 44.89           C  
+ATOM    877  O   SER B  18       2.676  14.593 -42.591  1.00 55.66           O  
+ATOM    878  CB  SER B  18       2.092  13.655 -39.676  1.00 34.25           C  
+ATOM    879  OG  SER B  18       3.427  13.391 -39.286  1.00 43.84           O  
+ATOM    880  N   GLY B  19       3.761  12.632 -42.379  1.00 38.99           N  
+ATOM    881  CA  GLY B  19       4.822  12.993 -43.303  1.00 40.92           C  
+ATOM    882  C   GLY B  19       4.434  12.847 -44.762  1.00 36.47           C  
+ATOM    883  O   GLY B  19       5.218  13.165 -45.656  1.00 52.51           O  
+ATOM    884  N   ARG B  20       3.223  12.354 -44.998  1.00 52.07           N  
+ATOM    885  CA  ARG B  20       2.788  11.962 -46.335  1.00 47.27           C  
+ATOM    886  C   ARG B  20       2.485  13.158 -47.237  1.00 57.42           C  
+ATOM    887  O   ARG B  20       3.111  13.329 -48.283  1.00 65.78           O  
+ATOM    888  CB  ARG B  20       1.555  11.059 -46.243  1.00 38.44           C  
+ATOM    889  CG  ARG B  20       1.790   9.796 -45.434  1.00 56.12           C  
+ATOM    890  CD  ARG B  20       0.735   8.738 -45.704  1.00 62.54           C  
+ATOM    891  NE  ARG B  20       1.123   7.442 -45.152  1.00 62.07           N  
+ATOM    892  CZ  ARG B  20       0.438   6.317 -45.324  1.00 70.15           C  
+ATOM    893  NH1 ARG B  20      -0.679   6.320 -46.039  1.00 82.26           N1+
+ATOM    894  NH2 ARG B  20       0.871   5.186 -44.783  1.00 67.61           N  
+ATOM    895  N   GLU B  21       1.510  13.969 -46.838  1.00 51.81           N  
+ATOM    896  CA  GLU B  21       1.093  15.121 -47.633  1.00 52.50           C  
+ATOM    897  C   GLU B  21       1.174  16.444 -46.873  1.00 48.58           C  
+ATOM    898  O   GLU B  21       0.851  16.516 -45.687  1.00 50.64           O  
+ATOM    899  CB  GLU B  21      -0.327  14.906 -48.154  1.00 65.27           C  
+ATOM    900  CG  GLU B  21      -0.422  13.811 -49.201  1.00 66.13           C  
+ATOM    901  CD  GLU B  21      -1.633  12.923 -49.009  1.00 89.99           C  
+ATOM    902  OE1 GLU B  21      -2.546  13.315 -48.253  1.00 97.51           O  
+ATOM    903  OE2 GLU B  21      -1.666  11.828 -49.610  1.00 90.81           O1-
+ATOM    904  N   GLY B  22       1.603  17.487 -47.580  1.00 57.42           N  
+ATOM    905  CA  GLY B  22       1.656  18.833 -47.037  1.00 40.82           C  
+ATOM    906  C   GLY B  22       2.604  18.937 -45.862  1.00 41.22           C  
+ATOM    907  O   GLY B  22       3.738  18.467 -45.938  1.00 57.37           O  
+ATOM    908  N   ASP B  23       2.151  19.565 -44.782  1.00 49.48           N  
+ATOM    909  CA  ASP B  23       2.984  19.710 -43.597  1.00 48.67           C  
+ATOM    910  C   ASP B  23       3.336  18.317 -43.076  1.00 51.11           C  
+ATOM    911  O   ASP B  23       2.457  17.536 -42.714  1.00 55.96           O  
+ATOM    912  CB  ASP B  23       2.262  20.542 -42.529  1.00 54.98           C  
+ATOM    913  CG  ASP B  23       3.160  20.920 -41.358  1.00 50.63           C  
+ATOM    914  OD1 ASP B  23       4.232  20.303 -41.179  1.00 57.30           O  
+ATOM    915  OD2 ASP B  23       2.790  21.852 -40.614  1.00 57.02           O1-
+ATOM    916  N   LYS B  24       4.630  18.017 -43.042  1.00 49.18           N  
+ATOM    917  CA  LYS B  24       5.101  16.690 -42.663  1.00 30.76           C  
+ATOM    918  C   LYS B  24       5.016  16.496 -41.151  1.00 43.40           C  
+ATOM    919  O   LYS B  24       5.262  15.402 -40.643  1.00 45.34           O  
+ATOM    920  CB  LYS B  24       6.523  16.430 -43.180  1.00 31.32           C  
+ATOM    921  CG  LYS B  24       7.645  17.226 -42.545  1.00 49.72           C  
+ATOM    922  CD  LYS B  24       8.979  16.725 -43.100  1.00 41.93           C  
+ATOM    923  CE  LYS B  24      10.177  17.332 -42.388  1.00 50.24           C  
+ATOM    924  NZ  LYS B  24      10.424  18.741 -42.799  1.00 72.79           N1+
+ATOM    925  N   HIS B  25       4.671  17.564 -40.437  1.00 47.78           N  
+ATOM    926  CA  HIS B  25       4.632  17.526 -38.981  1.00 43.93           C  
+ATOM    927  C   HIS B  25       3.196  17.584 -38.454  1.00 43.55           C  
+ATOM    928  O   HIS B  25       2.974  17.651 -37.245  1.00 55.73           O  
+ATOM    929  CB  HIS B  25       5.432  18.699 -38.409  1.00 58.97           C  
+ATOM    930  CG  HIS B  25       6.903  18.620 -38.676  1.00 71.22           C  
+ATOM    931  ND1 HIS B  25       7.628  17.456 -38.531  1.00 86.54           N  
+ATOM    932  CD2 HIS B  25       7.783  19.561 -39.092  1.00 62.82           C  
+ATOM    933  CE1 HIS B  25       8.892  17.686 -38.839  1.00 66.21           C  
+ATOM    934  NE2 HIS B  25       9.012  18.956 -39.183  1.00 74.29           N  
+ATOM    935  N   LYS B  26       2.227  17.557 -39.365  1.00 50.45           N  
+ATOM    936  CA  LYS B  26       0.806  17.577 -39.008  1.00 42.35           C  
+ATOM    937  C   LYS B  26      -0.012  16.623 -39.877  1.00 57.48           C  
+ATOM    938  O   LYS B  26       0.394  16.283 -40.989  1.00 44.73           O  
+ATOM    939  CB  LYS B  26       0.232  18.993 -39.115  1.00 47.43           C  
+ATOM    940  CG  LYS B  26       0.786  19.973 -38.096  1.00 56.20           C  
+ATOM    941  CD  LYS B  26       0.243  21.372 -38.323  1.00 51.01           C  
+ATOM    942  CE  LYS B  26       0.897  22.367 -37.382  1.00 65.88           C  
+ATOM    943  NZ  LYS B  26       2.381  22.249 -37.403  1.00 53.90           N1+
+ATOM    944  N   LEU B  27      -1.167  16.197 -39.368  1.00 49.34           N  
+ATOM    945  CA  LEU B  27      -2.078  15.369 -40.152  1.00 35.75           C  
+ATOM    946  C   LEU B  27      -3.261  16.151 -40.719  1.00 40.92           C  
+ATOM    947  O   LEU B  27      -4.138  16.589 -39.977  1.00 48.27           O  
+ATOM    948  CB  LEU B  27      -2.622  14.219 -39.298  1.00 54.82           C  
+ATOM    949  CG  LEU B  27      -1.704  13.139 -38.728  1.00 37.81           C  
+ATOM    950  CD1 LEU B  27      -2.370  12.479 -37.535  1.00 34.11           C  
+ATOM    951  CD2 LEU B  27      -1.414  12.101 -39.785  1.00 39.25           C  
+ATOM    952  N   LYS B  28      -3.285  16.314 -42.038  1.00 41.73           N  
+ATOM    953  CA  LYS B  28      -4.468  16.808 -42.735  1.00 54.39           C  
+ATOM    954  C   LYS B  28      -5.546  15.729 -42.699  1.00 53.12           C  
+ATOM    955  O   LYS B  28      -5.259  14.587 -42.339  1.00 48.04           O  
+ATOM    956  CB  LYS B  28      -4.132  17.211 -44.171  1.00 44.55           C  
+ATOM    957  CG  LYS B  28      -3.385  16.158 -44.962  1.00 45.10           C  
+ATOM    958  CD  LYS B  28      -2.530  16.801 -46.043  1.00 44.10           C  
+ATOM    959  CE  LYS B  28      -3.370  17.622 -47.004  1.00 56.39           C  
+ATOM    960  NZ  LYS B  28      -2.537  18.291 -48.042  1.00 59.72           N1+
+ATOM    961  N   LYS B  29      -6.779  16.084 -43.057  1.00 55.33           N  
+ATOM    962  CA  LYS B  29      -7.886  15.130 -42.993  1.00 50.33           C  
+ATOM    963  C   LYS B  29      -7.604  13.872 -43.808  1.00 49.65           C  
+ATOM    964  O   LYS B  29      -7.960  12.766 -43.402  1.00 53.56           O  
+ATOM    965  CB  LYS B  29      -9.179  15.764 -43.506  1.00 62.80           C  
+ATOM    966  CG  LYS B  29      -9.663  16.991 -42.758  1.00 71.85           C  
+ATOM    967  CD  LYS B  29     -10.999  17.439 -43.335  1.00 65.32           C  
+ATOM    968  CE  LYS B  29     -11.379  18.837 -42.885  1.00 79.39           C  
+ATOM    969  NZ  LYS B  29     -12.628  19.296 -43.557  1.00 80.73           N1+
+ATOM    970  N   SER B  30      -6.970  14.059 -44.962  1.00 65.90           N  
+ATOM    971  CA  SER B  30      -6.536  12.956 -45.812  1.00 48.36           C  
+ATOM    972  C   SER B  30      -5.744  11.915 -45.035  1.00 53.83           C  
+ATOM    973  O   SER B  30      -6.035  10.720 -45.084  1.00 48.23           O  
+ATOM    974  CB  SER B  30      -5.696  13.477 -46.978  1.00 57.62           C  
+ATOM    975  OG  SER B  30      -5.048  12.409 -47.646  1.00 63.90           O  
+ATOM    976  N   GLU B  31      -4.731  12.391 -44.319  1.00 53.93           N  
+ATOM    977  CA  GLU B  31      -3.820  11.517 -43.600  1.00 45.97           C  
+ATOM    978  C   GLU B  31      -4.453  10.921 -42.347  1.00 48.55           C  
+ATOM    979  O   GLU B  31      -4.202   9.764 -42.011  1.00 49.91           O  
+ATOM    980  CB  GLU B  31      -2.558  12.292 -43.218  1.00 46.80           C  
+ATOM    981  CG  GLU B  31      -1.703  12.733 -44.396  1.00 45.27           C  
+ATOM    982  CD  GLU B  31      -0.766  13.868 -44.031  1.00 39.26           C  
+ATOM    983  OE1 GLU B  31      -1.105  14.639 -43.112  1.00 50.94           O  
+ATOM    984  OE2 GLU B  31       0.311  13.988 -44.653  1.00 54.71           O1-
+ATOM    985  N   LEU B  32      -5.271  11.713 -41.661  1.00 48.64           N  
+ATOM    986  CA  LEU B  32      -5.997  11.238 -40.488  1.00 41.29           C  
+ATOM    987  C   LEU B  32      -6.900  10.043 -40.794  1.00 43.19           C  
+ATOM    988  O   LEU B  32      -6.912   9.059 -40.052  1.00 44.81           O  
+ATOM    989  CB  LEU B  32      -6.829  12.372 -39.883  1.00 45.72           C  
+ATOM    990  CG  LEU B  32      -7.683  12.006 -38.666  1.00 66.78           C  
+ATOM    991  CD1 LEU B  32      -6.823  11.375 -37.582  1.00 63.13           C  
+ATOM    992  CD2 LEU B  32      -8.427  13.223 -38.128  1.00 42.04           C  
+ATOM    993  N   LYS B  33      -7.656  10.139 -41.885  1.00 46.18           N  
+ATOM    994  CA  LYS B  33      -8.565   9.072 -42.301  1.00 43.91           C  
+ATOM    995  C   LYS B  33      -7.869   7.735 -42.524  1.00 48.38           C  
+ATOM    996  O   LYS B  33      -8.322   6.701 -42.035  1.00 58.28           O  
+ATOM    997  CB  LYS B  33      -9.302   9.475 -43.581  1.00 60.62           C  
+ATOM    998  CG  LYS B  33     -10.184   8.377 -44.157  1.00 50.94           C  
+ATOM    999  CD  LYS B  33     -10.802   8.794 -45.480  1.00 45.52           C  
+ATOM   1000  CE  LYS B  33     -11.661   7.680 -46.054  1.00 58.14           C  
+ATOM   1001  NZ  LYS B  33     -12.314   8.067 -47.335  1.00 73.21           N1+
+ATOM   1002  N   GLU B  34      -6.764   7.763 -43.261  1.00 43.09           N  
+ATOM   1003  CA  GLU B  34      -6.000   6.554 -43.536  1.00 36.62           C  
+ATOM   1004  C   GLU B  34      -5.433   5.959 -42.250  1.00 45.36           C  
+ATOM   1005  O   GLU B  34      -5.463   4.746 -42.061  1.00 62.44           O  
+ATOM   1006  CB  GLU B  34      -4.894   6.840 -44.551  1.00 46.60           C  
+ATOM   1007  CG  GLU B  34      -5.427   7.410 -45.859  1.00 71.65           C  
+ATOM   1008  CD  GLU B  34      -4.332   7.753 -46.850  1.00108.74           C  
+ATOM   1009  OE1 GLU B  34      -3.163   7.397 -46.594  1.00107.99           O  
+ATOM   1010  OE2 GLU B  34      -4.643   8.379 -47.885  1.00117.56           O1-
+ATOM   1011  N   LEU B  35      -4.906   6.818 -41.380  1.00 49.07           N  
+ATOM   1012  CA  LEU B  35      -4.362   6.385 -40.094  1.00 41.43           C  
+ATOM   1013  C   LEU B  35      -5.411   5.591 -39.322  1.00 40.75           C  
+ATOM   1014  O   LEU B  35      -5.172   4.447 -38.938  1.00 61.92           O  
+ATOM   1015  CB  LEU B  35      -3.888   7.590 -39.273  1.00 40.81           C  
+ATOM   1016  CG  LEU B  35      -3.065   7.350 -38.002  1.00 47.53           C  
+ATOM   1017  CD1 LEU B  35      -2.130   8.525 -37.750  1.00 52.90           C  
+ATOM   1018  CD2 LEU B  35      -3.959   7.119 -36.785  1.00 41.12           C  
+ATOM   1019  N   ILE B  36      -6.559   6.218 -39.085  1.00 44.26           N  
+ATOM   1020  CA  ILE B  36      -7.676   5.581 -38.390  1.00 40.89           C  
+ATOM   1021  C   ILE B  36      -8.076   4.273 -39.068  1.00 53.87           C  
+ATOM   1022  O   ILE B  36      -8.240   3.244 -38.412  1.00 56.52           O  
+ATOM   1023  CB  ILE B  36      -8.903   6.512 -38.315  1.00 44.07           C  
+ATOM   1024  CG1 ILE B  36      -8.599   7.721 -37.427  1.00 43.62           C  
+ATOM   1025  CG2 ILE B  36     -10.115   5.762 -37.782  1.00 55.90           C  
+ATOM   1026  CD1 ILE B  36      -9.640   8.815 -37.500  1.00 42.34           C  
+ATOM   1027  N   ASN B  37      -8.229   4.322 -40.388  1.00 59.62           N  
+ATOM   1028  CA  ASN B  37      -8.702   3.173 -41.148  1.00 39.90           C  
+ATOM   1029  C   ASN B  37      -7.670   2.053 -41.225  1.00 44.51           C  
+ATOM   1030  O   ASN B  37      -8.030   0.878 -41.303  1.00 70.91           O  
+ATOM   1031  CB  ASN B  37      -9.092   3.597 -42.567  1.00 43.47           C  
+ATOM   1032  CG  ASN B  37     -10.422   4.322 -42.615  1.00 59.09           C  
+ATOM   1033  OD1 ASN B  37     -11.197   4.288 -41.659  1.00 64.29           O  
+ATOM   1034  ND2 ASN B  37     -10.695   4.984 -43.734  1.00 61.06           N  
+ATOM   1035  N   ASN B  38      -6.390   2.410 -41.205  1.00 51.01           N  
+ATOM   1036  CA  ASN B  38      -5.346   1.400 -41.318  1.00 53.99           C  
+ATOM   1037  C   ASN B  38      -4.825   0.916 -39.967  1.00 42.24           C  
+ATOM   1038  O   ASN B  38      -4.446  -0.247 -39.826  1.00 46.41           O  
+ATOM   1039  CB  ASN B  38      -4.176   1.953 -42.133  1.00 50.86           C  
+ATOM   1040  CG  ASN B  38      -4.508   2.113 -43.602  1.00 46.88           C  
+ATOM   1041  OD1 ASN B  38      -5.457   1.513 -44.109  1.00 53.00           O  
+ATOM   1042  ND2 ASN B  38      -3.732   2.940 -44.293  1.00 46.01           N  
+ATOM   1043  N   GLU B  39      -4.806   1.803 -38.976  1.00 49.69           N  
+ATOM   1044  CA  GLU B  39      -4.168   1.476 -37.703  1.00 49.51           C  
+ATOM   1045  C   GLU B  39      -5.136   1.337 -36.527  1.00 38.34           C  
+ATOM   1046  O   GLU B  39      -4.766   0.801 -35.487  1.00 59.58           O  
+ATOM   1047  CB  GLU B  39      -3.108   2.531 -37.367  1.00 56.83           C  
+ATOM   1048  CG  GLU B  39      -2.199   2.906 -38.533  1.00 42.22           C  
+ATOM   1049  CD  GLU B  39      -1.326   1.754 -39.011  1.00 48.67           C  
+ATOM   1050  OE1 GLU B  39      -1.159   0.767 -38.263  1.00 65.66           O  
+ATOM   1051  OE2 GLU B  39      -0.802   1.838 -40.141  1.00 49.63           O1-
+ATOM   1052  N   LEU B  40      -6.366   1.817 -36.685  1.00 41.61           N  
+ATOM   1053  CA  LEU B  40      -7.378   1.680 -35.635  1.00 43.17           C  
+ATOM   1054  C   LEU B  40      -8.608   0.890 -36.086  1.00 51.24           C  
+ATOM   1055  O   LEU B  40      -9.720   1.145 -35.625  1.00 60.11           O  
+ATOM   1056  CB  LEU B  40      -7.799   3.060 -35.124  1.00 54.68           C  
+ATOM   1057  CG  LEU B  40      -6.713   3.850 -34.388  1.00 49.28           C  
+ATOM   1058  CD1 LEU B  40      -7.192   5.254 -34.060  1.00 43.92           C  
+ATOM   1059  CD2 LEU B  40      -6.287   3.121 -33.121  1.00 44.65           C  
+ATOM   1060  N   SER B  41      -8.402  -0.066 -36.984  1.00 57.78           N  
+ATOM   1061  CA  SER B  41      -9.498  -0.824 -37.587  1.00 56.29           C  
+ATOM   1062  C   SER B  41     -10.166  -1.831 -36.646  1.00 65.37           C  
+ATOM   1063  O   SER B  41     -11.073  -2.556 -37.056  1.00 68.36           O  
+ATOM   1064  CB  SER B  41      -8.999  -1.556 -38.834  1.00 39.01           C  
+ATOM   1065  OG  SER B  41      -8.117  -2.610 -38.487  1.00 53.05           O  
+ATOM   1066  N   HIS B  42      -9.725  -1.877 -35.393  1.00 65.98           N  
+ATOM   1067  CA  HIS B  42     -10.353  -2.748 -34.400  1.00 49.38           C  
+ATOM   1068  C   HIS B  42     -11.026  -1.971 -33.275  1.00 61.75           C  
+ATOM   1069  O   HIS B  42     -11.851  -2.513 -32.539  1.00 62.00           O  
+ATOM   1070  CB  HIS B  42      -9.314  -3.700 -33.808  1.00 50.07           C  
+ATOM   1071  CG  HIS B  42      -8.731  -4.650 -34.805  1.00 48.51           C  
+ATOM   1072  ND1 HIS B  42      -7.529  -4.418 -35.437  1.00 62.86           N  
+ATOM   1073  CD2 HIS B  42      -9.191  -5.827 -35.293  1.00 55.61           C  
+ATOM   1074  CE1 HIS B  42      -7.268  -5.414 -36.263  1.00 60.88           C  
+ATOM   1075  NE2 HIS B  42      -8.261  -6.282 -36.195  1.00 61.59           N  
+ATOM   1076  N   PHE B  43     -10.669  -0.700 -33.148  1.00 60.71           N  
+ATOM   1077  CA  PHE B  43     -11.191   0.148 -32.084  1.00 51.41           C  
+ATOM   1078  C   PHE B  43     -12.240   1.129 -32.603  1.00 59.03           C  
+ATOM   1079  O   PHE B  43     -13.221   1.415 -31.919  1.00 73.66           O  
+ATOM   1080  CB  PHE B  43     -10.049   0.896 -31.391  1.00 56.21           C  
+ATOM   1081  CG  PHE B  43      -9.134   0.004 -30.593  1.00 55.15           C  
+ATOM   1082  CD1 PHE B  43      -9.461  -1.324 -30.363  1.00 59.92           C  
+ATOM   1083  CD2 PHE B  43      -7.947   0.493 -30.075  1.00 55.47           C  
+ATOM   1084  CE1 PHE B  43      -8.624  -2.146 -29.632  1.00 62.11           C  
+ATOM   1085  CE2 PHE B  43      -7.104  -0.325 -29.342  1.00 53.41           C  
+ATOM   1086  CZ  PHE B  43      -7.443  -1.645 -29.121  1.00 55.35           C  
+ATOM   1087  N   LEU B  44     -12.036   1.635 -33.815  1.00 58.67           N  
+ATOM   1088  CA  LEU B  44     -12.941   2.623 -34.395  1.00 66.98           C  
+ATOM   1089  C   LEU B  44     -13.581   2.110 -35.682  1.00 73.84           C  
+ATOM   1090  O   LEU B  44     -12.940   1.407 -36.463  1.00 70.25           O  
+ATOM   1091  CB  LEU B  44     -12.193   3.925 -34.684  1.00 58.84           C  
+ATOM   1092  CG  LEU B  44     -11.535   4.647 -33.509  1.00 58.69           C  
+ATOM   1093  CD1 LEU B  44     -10.829   5.895 -34.005  1.00 52.38           C  
+ATOM   1094  CD2 LEU B  44     -12.557   4.993 -32.439  1.00 52.86           C  
+ATOM   1095  N   GLU B  45     -14.845   2.467 -35.898  1.00 66.49           N  
+ATOM   1096  CA  GLU B  45     -15.548   2.076 -37.116  1.00 61.92           C  
+ATOM   1097  C   GLU B  45     -14.900   2.728 -38.326  1.00 66.76           C  
+ATOM   1098  O   GLU B  45     -14.524   3.899 -38.276  1.00 69.32           O  
+ATOM   1099  CB  GLU B  45     -17.024   2.475 -37.056  1.00 80.75           C  
+ATOM   1100  CG  GLU B  45     -17.867   1.698 -36.065  1.00 81.81           C  
+ATOM   1101  CD  GLU B  45     -19.293   2.211 -36.006  1.00 97.21           C  
+ATOM   1102  OE1 GLU B  45     -19.924   2.335 -37.076  1.00112.35           O  
+ATOM   1103  OE2 GLU B  45     -19.777   2.502 -34.891  1.00112.23           O1-
+ATOM   1104  N   GLU B  46     -14.751   1.955 -39.399  1.00 74.84           N  
+ATOM   1105  CA  GLU B  46     -14.142   2.452 -40.626  1.00 69.22           C  
+ATOM   1106  C   GLU B  46     -14.804   3.737 -41.108  1.00 72.59           C  
+ATOM   1107  O   GLU B  46     -16.021   3.896 -41.008  1.00 88.50           O  
+ATOM   1108  CB  GLU B  46     -14.221   1.389 -41.724  1.00 76.56           C  
+ATOM   1109  CG  GLU B  46     -13.477   1.758 -42.997  1.00 65.42           C  
+ATOM   1110  CD  GLU B  46     -13.841   0.868 -44.166  1.00 74.60           C  
+ATOM   1111  OE1 GLU B  46     -14.686  -0.036 -43.990  1.00 88.84           O  
+ATOM   1112  OE2 GLU B  46     -13.282   1.074 -45.264  1.00100.48           O1-
+ATOM   1113  N   ILE B  47     -13.992   4.656 -41.617  1.00 69.87           N  
+ATOM   1114  CA  ILE B  47     -14.495   5.891 -42.200  1.00 64.89           C  
+ATOM   1115  C   ILE B  47     -14.548   5.838 -43.726  1.00 71.91           C  
+ATOM   1116  O   ILE B  47     -13.532   5.587 -44.374  1.00 79.26           O  
+ATOM   1117  CB  ILE B  47     -13.642   7.095 -41.769  1.00 66.51           C  
+ATOM   1118  CG1 ILE B  47     -13.533   7.146 -40.242  1.00 66.48           C  
+ATOM   1119  CG2 ILE B  47     -14.245   8.377 -42.297  1.00 62.62           C  
+ATOM   1120  CD1 ILE B  47     -12.730   8.320 -39.720  1.00 49.47           C  
+ATOM   1121  N   LYS B  48     -15.727   6.075 -44.296  1.00 91.00           N  
+ATOM   1122  CA  LYS B  48     -15.886   6.067 -45.748  1.00 89.27           C  
+ATOM   1123  C   LYS B  48     -16.692   7.283 -46.182  1.00 91.47           C  
+ATOM   1124  O   LYS B  48     -16.778   7.603 -47.368  1.00104.94           O  
+ATOM   1125  CB  LYS B  48     -16.594   4.795 -46.220  1.00 86.22           C  
+ATOM   1126  CG  LYS B  48     -15.803   3.515 -46.050  1.00 96.04           C  
+ATOM   1127  CD  LYS B  48     -16.718   2.312 -46.220  1.00 94.82           C  
+ATOM   1128  CE  LYS B  48     -17.770   2.254 -45.122  1.00 89.59           C  
+ATOM   1129  NZ  LYS B  48     -18.603   1.022 -45.213  1.00 88.09           N1+
+ATOM   1130  N   GLU B  49     -17.263   7.964 -45.195  1.00 88.88           N  
+ATOM   1131  CA  GLU B  49     -17.950   9.235 -45.394  1.00 89.35           C  
+ATOM   1132  C   GLU B  49     -17.137  10.467 -45.029  1.00 75.14           C  
+ATOM   1133  O   GLU B  49     -16.506  10.524 -43.973  1.00 83.25           O  
+ATOM   1134  CB  GLU B  49     -19.264   9.245 -44.613  1.00100.98           C  
+ATOM   1135  CG  GLU B  49     -20.210   8.149 -45.047  1.00111.33           C  
+ATOM   1136  CD  GLU B  49     -20.455   8.171 -46.546  1.00126.45           C  
+ATOM   1137  OE1 GLU B  49     -20.711   9.264 -47.096  1.00133.96           O  
+ATOM   1138  OE2 GLU B  49     -20.380   7.096 -47.176  1.00137.55           O1-
+ATOM   1139  N   GLN B  50     -17.167  11.451 -45.923  1.00 81.71           N  
+ATOM   1140  CA  GLN B  50     -16.413  12.686 -45.764  1.00 68.11           C  
+ATOM   1141  C   GLN B  50     -16.982  13.423 -44.559  1.00 78.88           C  
+ATOM   1142  O   GLN B  50     -16.262  14.131 -43.856  1.00 86.65           O  
+ATOM   1143  CB  GLN B  50     -16.515  13.556 -47.026  1.00 69.82           C  
+ATOM   1144  CG  GLN B  50     -15.766  14.896 -46.984  1.00 69.98           C  
+ATOM   1145  CD  GLN B  50     -14.271  14.762 -46.734  1.00 85.24           C  
+ATOM   1146  OE1 GLN B  50     -13.690  13.690 -46.907  1.00 96.91           O  
+ATOM   1147  NE2 GLN B  50     -13.644  15.855 -46.312  1.00 98.80           N  
+ATOM   1148  N   GLU B  51     -18.286  13.263 -44.342  1.00 89.89           N  
+ATOM   1149  CA  GLU B  51     -18.966  13.888 -43.213  1.00 86.32           C  
+ATOM   1150  C   GLU B  51     -18.328  13.471 -41.890  1.00 70.60           C  
+ATOM   1151  O   GLU B  51     -18.155  14.287 -40.984  1.00 77.36           O  
+ATOM   1152  CB  GLU B  51     -20.445  13.491 -43.218  1.00 79.95           C  
+ATOM   1153  CG  GLU B  51     -21.442  14.618 -43.012  1.00 99.30           C  
+ATOM   1154  CD  GLU B  51     -22.863  14.094 -42.894  1.00115.74           C  
+ATOM   1155  OE1 GLU B  51     -23.060  13.083 -42.188  1.00118.37           O  
+ATOM   1156  OE2 GLU B  51     -23.778  14.678 -43.513  1.00104.85           O1-
+ATOM   1157  N   VAL B  52     -17.985  12.189 -41.796  1.00 74.22           N  
+ATOM   1158  CA  VAL B  52     -17.324  11.626 -40.620  1.00 82.19           C  
+ATOM   1159  C   VAL B  52     -15.972  12.284 -40.354  1.00 78.45           C  
+ATOM   1160  O   VAL B  52     -15.672  12.699 -39.233  1.00 72.49           O  
+ATOM   1161  CB  VAL B  52     -17.121  10.106 -40.758  1.00 75.28           C  
+ATOM   1162  CG1 VAL B  52     -16.287   9.582 -39.599  1.00 72.03           C  
+ATOM   1163  CG2 VAL B  52     -18.462   9.393 -40.805  1.00 66.28           C  
+ATOM   1164  N   VAL B  53     -15.166  12.378 -41.408  1.00 64.35           N  
+ATOM   1165  CA  VAL B  53     -13.815  12.916 -41.308  1.00 57.27           C  
+ATOM   1166  C   VAL B  53     -13.830  14.404 -40.978  1.00 71.75           C  
+ATOM   1167  O   VAL B  53     -12.963  14.900 -40.253  1.00 73.55           O  
+ATOM   1168  CB  VAL B  53     -13.040  12.677 -42.635  1.00 66.07           C  
+ATOM   1169  CG1 VAL B  53     -12.047  13.791 -42.916  1.00 69.94           C  
+ATOM   1170  CG2 VAL B  53     -12.343  11.331 -42.612  1.00 77.64           C  
+ATOM   1171  N   ASP B  54     -14.845  15.101 -41.474  1.00 77.78           N  
+ATOM   1172  CA  ASP B  54     -15.059  16.498 -41.124  1.00 67.71           C  
+ATOM   1173  C   ASP B  54     -15.260  16.635 -39.618  1.00 66.40           C  
+ATOM   1174  O   ASP B  54     -14.674  17.506 -38.974  1.00 74.13           O  
+ATOM   1175  CB  ASP B  54     -16.259  17.066 -41.883  1.00 91.71           C  
+ATOM   1176  CG  ASP B  54     -15.914  17.462 -43.307  1.00 92.33           C  
+ATOM   1177  OD1 ASP B  54     -14.711  17.600 -43.615  1.00 82.90           O  
+ATOM   1178  OD2 ASP B  54     -16.847  17.637 -44.119  1.00101.20           O1-
+ATOM   1179  N   LYS B  55     -16.101  15.763 -39.070  1.00 63.64           N  
+ATOM   1180  CA  LYS B  55     -16.496  15.834 -37.668  1.00 71.62           C  
+ATOM   1181  C   LYS B  55     -15.390  15.398 -36.710  1.00 67.99           C  
+ATOM   1182  O   LYS B  55     -15.198  16.012 -35.659  1.00 66.57           O  
+ATOM   1183  CB  LYS B  55     -17.745  14.981 -37.432  1.00 70.30           C  
+ATOM   1184  N   VAL B  56     -14.665  14.343 -37.073  1.00 69.85           N  
+ATOM   1185  CA  VAL B  56     -13.542  13.877 -36.264  1.00 66.66           C  
+ATOM   1186  C   VAL B  56     -12.450  14.936 -36.164  1.00 61.75           C  
+ATOM   1187  O   VAL B  56     -11.946  15.218 -35.076  1.00 66.57           O  
+ATOM   1188  CB  VAL B  56     -12.937  12.578 -36.834  1.00 55.17           C  
+ATOM   1189  CG1 VAL B  56     -11.704  12.170 -36.043  1.00 56.04           C  
+ATOM   1190  CG2 VAL B  56     -13.973  11.464 -36.830  1.00 80.70           C  
+ATOM   1191  N   MET B  57     -12.094  15.527 -37.299  1.00 57.81           N  
+ATOM   1192  CA  MET B  57     -11.082  16.575 -37.321  1.00 62.59           C  
+ATOM   1193  C   MET B  57     -11.542  17.787 -36.522  1.00 68.34           C  
+ATOM   1194  O   MET B  57     -10.750  18.411 -35.821  1.00 79.28           O  
+ATOM   1195  CB  MET B  57     -10.750  16.981 -38.758  1.00 65.50           C  
+ATOM   1196  CG  MET B  57      -9.741  18.117 -38.861  1.00 83.78           C  
+ATOM   1197  SD  MET B  57      -8.083  17.663 -38.308  1.00 71.13           S  
+ATOM   1198  CE  MET B  57      -7.572  16.554 -39.618  1.00 55.19           C  
+ATOM   1199  N   GLU B  58     -12.829  18.104 -36.621  1.00 72.22           N  
+ATOM   1200  CA  GLU B  58     -13.403  19.219 -35.878  1.00 75.62           C  
+ATOM   1201  C   GLU B  58     -13.251  19.032 -34.374  1.00 78.64           C  
+ATOM   1202  O   GLU B  58     -12.899  19.969 -33.657  1.00 81.30           O  
+ATOM   1203  CB  GLU B  58     -14.883  19.391 -36.223  1.00 89.87           C  
+ATOM   1204  CG  GLU B  58     -15.595  20.420 -35.358  1.00119.45           C  
+ATOM   1205  CD  GLU B  58     -17.104  20.278 -35.396  1.00125.62           C  
+ATOM   1206  OE1 GLU B  58     -17.761  20.663 -34.405  1.00121.84           O  
+ATOM   1207  OE2 GLU B  58     -17.634  19.784 -36.413  1.00123.04           O1-
+ATOM   1208  N   THR B  59     -13.511  17.819 -33.898  1.00 78.40           N  
+ATOM   1209  CA  THR B  59     -13.388  17.542 -32.476  1.00 84.35           C  
+ATOM   1210  C   THR B  59     -11.917  17.510 -32.083  1.00 76.80           C  
+ATOM   1211  O   THR B  59     -11.548  17.921 -30.982  1.00 76.47           O  
+ATOM   1212  CB  THR B  59     -14.056  16.198 -32.101  1.00 80.08           C  
+ATOM   1213  OG1 THR B  59     -15.448  16.243 -32.437  1.00 72.73           O  
+ATOM   1214  CG2 THR B  59     -13.909  15.911 -30.611  1.00 92.65           C  
+ATOM   1215  N   LEU B  60     -11.075  17.033 -32.994  1.00 73.32           N  
+ATOM   1216  CA  LEU B  60      -9.653  16.910 -32.703  1.00 66.39           C  
+ATOM   1217  C   LEU B  60      -8.886  18.228 -32.791  1.00 75.65           C  
+ATOM   1218  O   LEU B  60      -7.912  18.438 -32.069  1.00 69.32           O  
+ATOM   1219  CB  LEU B  60      -9.025  15.895 -33.654  1.00 69.53           C  
+ATOM   1220  CG  LEU B  60      -8.924  14.494 -33.060  1.00 82.96           C  
+ATOM   1221  CD1 LEU B  60      -7.871  13.673 -33.790  1.00 64.91           C  
+ATOM   1222  CD2 LEU B  60      -8.640  14.596 -31.569  1.00 86.31           C  
+ATOM   1223  N   ASP B  61      -9.335  19.112 -33.676  1.00 80.02           N  
+ATOM   1224  CA  ASP B  61      -8.614  20.350 -33.961  1.00 67.86           C  
+ATOM   1225  C   ASP B  61      -8.972  21.425 -32.944  1.00 75.12           C  
+ATOM   1226  O   ASP B  61     -10.085  21.950 -32.964  1.00100.27           O  
+ATOM   1227  CB  ASP B  61      -8.902  20.848 -35.378  1.00 68.94           C  
+ATOM   1228  CG  ASP B  61      -7.929  21.928 -35.827  1.00 73.09           C  
+ATOM   1229  OD1 ASP B  61      -6.806  21.996 -35.274  1.00 73.66           O  
+ATOM   1230  OD2 ASP B  61      -8.290  22.709 -36.732  1.00 70.34           O1-
+ATOM   1231  N   ASN B  62      -8.047  21.751 -32.050  1.00 79.77           N  
+ATOM   1232  CA  ASN B  62      -8.353  22.707 -30.994  1.00 86.37           C  
+ATOM   1233  C   ASN B  62      -7.720  24.067 -31.269  1.00 82.46           C  
+ATOM   1234  O   ASN B  62      -8.157  25.084 -30.731  1.00101.47           O  
+ATOM   1235  CB  ASN B  62      -7.880  22.172 -29.642  1.00 85.17           C  
+ATOM   1236  CG  ASN B  62      -8.651  20.943 -29.203  1.00101.38           C  
+ATOM   1237  OD1 ASN B  62      -9.838  20.802 -29.495  1.00 95.85           O  
+ATOM   1238  ND2 ASN B  62      -7.974  20.041 -28.501  1.00107.43           N  
+ATOM   1239  N   ASP B  63      -6.691  24.079 -32.109  1.00 81.86           N  
+ATOM   1240  CA  ASP B  63      -6.018  25.320 -32.479  1.00 84.53           C  
+ATOM   1241  C   ASP B  63      -6.578  25.931 -33.766  1.00 74.28           C  
+ATOM   1242  O   ASP B  63      -6.169  27.021 -34.163  1.00 86.11           O  
+ATOM   1243  CB  ASP B  63      -4.513  25.089 -32.622  1.00 84.81           C  
+ATOM   1244  CG  ASP B  63      -4.180  24.093 -33.710  1.00 90.41           C  
+ATOM   1245  OD1 ASP B  63      -5.098  23.372 -34.151  1.00 83.81           O  
+ATOM   1246  OD2 ASP B  63      -3.003  24.034 -34.126  1.00100.33           O1-
+ATOM   1247  N   GLY B  64      -7.509  25.235 -34.414  1.00 76.72           N  
+ATOM   1248  CA  GLY B  64      -8.198  25.797 -35.565  1.00 65.75           C  
+ATOM   1249  C   GLY B  64      -7.315  26.037 -36.779  1.00 82.01           C  
+ATOM   1250  O   GLY B  64      -7.340  27.121 -37.362  1.00 83.92           O  
+ATOM   1251  N   ASP B  65      -6.533  25.033 -37.165  1.00 87.64           N  
+ATOM   1252  CA  ASP B  65      -5.694  25.141 -38.357  1.00 63.34           C  
+ATOM   1253  C   ASP B  65      -6.055  24.154 -39.467  1.00 70.97           C  
+ATOM   1254  O   ASP B  65      -5.414  24.116 -40.518  1.00 89.53           O  
+ATOM   1255  CB  ASP B  65      -4.241  24.915 -37.933  1.00 52.79           C  
+ATOM   1256  CG  ASP B  65      -4.018  23.513 -37.366  1.00 79.82           C  
+ATOM   1257  OD1 ASP B  65      -5.004  22.754 -37.257  1.00 86.27           O  
+ATOM   1258  OD2 ASP B  65      -2.878  23.171 -36.988  1.00 76.89           O1-
+ATOM   1259  N   GLY B  66      -7.086  23.361 -39.214  1.00 64.87           N  
+ATOM   1260  CA  GLY B  66      -7.619  22.413 -40.175  1.00 63.75           C  
+ATOM   1261  C   GLY B  66      -6.779  21.155 -40.279  1.00 64.02           C  
+ATOM   1262  O   GLY B  66      -6.945  20.366 -41.210  1.00 69.45           O  
+ATOM   1263  N   GLU B  67      -5.881  20.961 -39.319  1.00 64.55           N  
+ATOM   1264  CA  GLU B  67      -5.006  19.794 -39.310  1.00 53.26           C  
+ATOM   1265  C   GLU B  67      -4.773  19.305 -37.890  1.00 62.67           C  
+ATOM   1266  O   GLU B  67      -5.053  20.018 -36.926  1.00 60.83           O  
+ATOM   1267  CB  GLU B  67      -3.659  20.104 -39.975  1.00 67.45           C  
+ATOM   1268  CG  GLU B  67      -3.730  20.440 -41.455  1.00 59.54           C  
+ATOM   1269  CD  GLU B  67      -2.359  20.501 -42.100  1.00 80.18           C  
+ATOM   1270  OE1 GLU B  67      -1.858  19.441 -42.531  1.00 80.71           O  
+ATOM   1271  OE2 GLU B  67      -1.782  21.607 -42.171  1.00101.64           O1-
+ATOM   1272  N   CYS B  68      -4.262  18.087 -37.760  1.00 60.09           N  
+ATOM   1273  CA  CYS B  68      -4.018  17.522 -36.444  1.00 53.40           C  
+ATOM   1274  C   CYS B  68      -2.518  17.467 -36.150  1.00 50.69           C  
+ATOM   1275  O   CYS B  68      -1.798  16.687 -36.771  1.00 61.44           O  
+ATOM   1276  CB  CYS B  68      -4.637  16.128 -36.334  1.00 49.33           C  
+ATOM   1277  SG  CYS B  68      -4.337  15.316 -34.752  1.00 57.22           S  
+ATOM   1278  N   ASP B  69      -2.037  18.295 -35.227  1.00 55.60           N  
+ATOM   1279  CA  ASP B  69      -0.630  18.224 -34.845  1.00 45.75           C  
+ATOM   1280  C   ASP B  69      -0.468  17.129 -33.792  1.00 47.00           C  
+ATOM   1281  O   ASP B  69      -1.445  16.470 -33.434  1.00 49.06           O  
+ATOM   1282  CB  ASP B  69      -0.109  19.582 -34.346  1.00 53.60           C  
+ATOM   1283  CG  ASP B  69      -0.676  19.987 -32.991  1.00 58.17           C  
+ATOM   1284  OD1 ASP B  69      -1.595  19.320 -32.478  1.00 64.53           O  
+ATOM   1285  OD2 ASP B  69      -0.190  20.993 -32.432  1.00 70.07           O1-
+ATOM   1286  N   PHE B  70       0.750  16.928 -33.298  1.00 58.40           N  
+ATOM   1287  CA  PHE B  70       1.006  15.805 -32.401  1.00 41.55           C  
+ATOM   1288  C   PHE B  70       0.270  15.966 -31.074  1.00 46.20           C  
+ATOM   1289  O   PHE B  70      -0.266  14.999 -30.534  1.00 62.84           O  
+ATOM   1290  CB  PHE B  70       2.502  15.643 -32.136  1.00 41.15           C  
+ATOM   1291  CG  PHE B  70       2.836  14.428 -31.322  1.00 48.22           C  
+ATOM   1292  CD1 PHE B  70       2.768  13.163 -31.884  1.00 54.09           C  
+ATOM   1293  CD2 PHE B  70       3.196  14.545 -29.989  1.00 56.01           C  
+ATOM   1294  CE1 PHE B  70       3.069  12.040 -31.137  1.00 58.09           C  
+ATOM   1295  CE2 PHE B  70       3.497  13.425 -29.237  1.00 50.92           C  
+ATOM   1296  CZ  PHE B  70       3.432  12.171 -29.812  1.00 39.14           C  
+ATOM   1297  N   GLN B  71       0.258  17.189 -30.552  1.00 68.52           N  
+ATOM   1298  CA  GLN B  71      -0.402  17.481 -29.283  1.00 51.23           C  
+ATOM   1299  C   GLN B  71      -1.891  17.139 -29.346  1.00 49.94           C  
+ATOM   1300  O   GLN B  71      -2.439  16.529 -28.429  1.00 58.44           O  
+ATOM   1301  CB  GLN B  71      -0.200  18.949 -28.897  1.00 53.18           C  
+ATOM   1302  CG  GLN B  71      -0.739  19.309 -27.522  1.00 80.10           C  
+ATOM   1303  CD  GLN B  71      -0.278  20.673 -27.051  1.00 84.38           C  
+ATOM   1304  OE1 GLN B  71       0.858  21.079 -27.299  1.00 92.87           O  
+ATOM   1305  NE2 GLN B  71      -1.172  21.404 -26.398  1.00 93.87           N  
+ATOM   1306  N   GLU B  72      -2.534  17.536 -30.438  1.00 45.56           N  
+ATOM   1307  CA  GLU B  72      -3.948  17.259 -30.656  1.00 46.86           C  
+ATOM   1308  C   GLU B  72      -4.189  15.765 -30.850  1.00 50.19           C  
+ATOM   1309  O   GLU B  72      -5.218  15.228 -30.440  1.00 51.21           O  
+ATOM   1310  CB  GLU B  72      -4.457  18.022 -31.886  1.00 57.53           C  
+ATOM   1311  CG  GLU B  72      -4.631  19.527 -31.707  1.00 60.66           C  
+ATOM   1312  CD  GLU B  72      -4.639  20.263 -33.040  1.00 56.53           C  
+ATOM   1313  OE1 GLU B  72      -4.015  19.760 -33.999  1.00 61.79           O  
+ATOM   1314  OE2 GLU B  72      -5.264  21.339 -33.140  1.00 77.09           O1-
+ATOM   1315  N   PHE B  73      -3.225  15.105 -31.485  1.00 55.36           N  
+ATOM   1316  CA  PHE B  73      -3.256  13.659 -31.689  1.00 51.04           C  
+ATOM   1317  C   PHE B  73      -3.135  12.847 -30.396  1.00 58.01           C  
+ATOM   1318  O   PHE B  73      -3.773  11.804 -30.253  1.00 57.71           O  
+ATOM   1319  CB  PHE B  73      -2.144  13.257 -32.663  1.00 45.30           C  
+ATOM   1320  CG  PHE B  73      -1.946  11.775 -32.787  1.00 50.54           C  
+ATOM   1321  CD1 PHE B  73      -2.860  11.001 -33.483  1.00 49.29           C  
+ATOM   1322  CD2 PHE B  73      -0.839  11.156 -32.228  1.00 62.20           C  
+ATOM   1323  CE1 PHE B  73      -2.684   9.635 -33.609  1.00 56.15           C  
+ATOM   1324  CE2 PHE B  73      -0.656   9.790 -32.352  1.00 59.65           C  
+ATOM   1325  CZ  PHE B  73      -1.579   9.029 -33.043  1.00 42.60           C  
+ATOM   1326  N   MET B  74      -2.310  13.310 -29.462  1.00 52.68           N  
+ATOM   1327  CA  MET B  74      -2.175  12.631 -28.174  1.00 52.23           C  
+ATOM   1328  C   MET B  74      -3.479  12.665 -27.388  1.00 58.19           C  
+ATOM   1329  O   MET B  74      -3.827  11.702 -26.703  1.00 54.46           O  
+ATOM   1330  CB  MET B  74      -1.048  13.249 -27.349  1.00 53.75           C  
+ATOM   1331  CG  MET B  74       0.336  12.825 -27.797  1.00 61.62           C  
+ATOM   1332  SD  MET B  74       0.506  11.030 -27.895  1.00 75.24           S  
+ATOM   1333  CE  MET B  74       0.109  10.543 -26.221  1.00 39.77           C  
+ATOM   1334  N   ALA B  75      -4.187  13.785 -27.485  1.00 68.25           N  
+ATOM   1335  CA  ALA B  75      -5.507  13.913 -26.884  1.00 55.75           C  
+ATOM   1336  C   ALA B  75      -6.437  12.854 -27.458  1.00 56.96           C  
+ATOM   1337  O   ALA B  75      -7.186  12.209 -26.727  1.00 65.79           O  
+ATOM   1338  CB  ALA B  75      -6.068  15.305 -27.116  1.00 61.48           C  
+ATOM   1339  N   PHE B  76      -6.372  12.680 -28.774  1.00 68.13           N  
+ATOM   1340  CA  PHE B  76      -7.159  11.670 -29.474  1.00 51.29           C  
+ATOM   1341  C   PHE B  76      -6.860  10.264 -28.967  1.00 45.77           C  
+ATOM   1342  O   PHE B  76      -7.775   9.493 -28.679  1.00 58.22           O  
+ATOM   1343  CB  PHE B  76      -6.881  11.745 -30.974  1.00 55.84           C  
+ATOM   1344  CG  PHE B  76      -7.532  10.657 -31.771  1.00 62.14           C  
+ATOM   1345  CD1 PHE B  76      -8.911  10.566 -31.837  1.00 60.80           C  
+ATOM   1346  CD2 PHE B  76      -6.769   9.741 -32.473  1.00 70.31           C  
+ATOM   1347  CE1 PHE B  76      -9.518   9.571 -32.577  1.00 51.36           C  
+ATOM   1348  CE2 PHE B  76      -7.371   8.745 -33.216  1.00 61.56           C  
+ATOM   1349  CZ  PHE B  76      -8.746   8.661 -33.268  1.00 51.24           C  
+ATOM   1350  N   VAL B  77      -5.575   9.934 -28.881  1.00 54.76           N  
+ATOM   1351  CA  VAL B  77      -5.136   8.655 -28.331  1.00 46.45           C  
+ATOM   1352  C   VAL B  77      -5.678   8.458 -26.917  1.00 51.72           C  
+ATOM   1353  O   VAL B  77      -6.150   7.377 -26.568  1.00 50.41           O  
+ATOM   1354  CB  VAL B  77      -3.597   8.547 -28.321  1.00 49.86           C  
+ATOM   1355  CG1 VAL B  77      -3.150   7.323 -27.538  1.00 46.04           C  
+ATOM   1356  CG2 VAL B  77      -3.063   8.493 -29.745  1.00 45.78           C  
+ATOM   1357  N   ALA B  78      -5.613   9.517 -26.115  1.00 54.34           N  
+ATOM   1358  CA  ALA B  78      -6.162   9.508 -24.762  1.00 45.58           C  
+ATOM   1359  C   ALA B  78      -7.649   9.159 -24.764  1.00 54.72           C  
+ATOM   1360  O   ALA B  78      -8.109   8.367 -23.940  1.00 64.00           O  
+ATOM   1361  CB  ALA B  78      -5.934  10.850 -24.092  1.00 56.78           C  
+ATOM   1362  N   MET B  79      -8.394   9.758 -25.689  1.00 48.17           N  
+ATOM   1363  CA  MET B  79      -9.842   9.585 -25.750  1.00 48.54           C  
+ATOM   1364  C   MET B  79     -10.184   8.140 -26.092  1.00 56.72           C  
+ATOM   1365  O   MET B  79     -10.977   7.494 -25.407  1.00 78.07           O  
+ATOM   1366  CB  MET B  79     -10.467  10.527 -26.786  1.00 52.76           C  
+ATOM   1367  CG  MET B  79     -10.294  12.011 -26.498  1.00 79.21           C  
+ATOM   1368  SD  MET B  79     -11.226  13.048 -27.646  1.00116.16           S  
+ATOM   1369  CE  MET B  79     -10.522  14.664 -27.316  1.00 84.67           C  
+ATOM   1370  N   VAL B  80      -9.570   7.647 -27.163  1.00 52.52           N  
+ATOM   1371  CA  VAL B  80      -9.756   6.276 -27.630  1.00 56.76           C  
+ATOM   1372  C   VAL B  80      -9.337   5.240 -26.585  1.00 64.52           C  
+ATOM   1373  O   VAL B  80     -10.059   4.275 -26.334  1.00 66.20           O  
+ATOM   1374  CB  VAL B  80      -8.969   6.029 -28.936  1.00 58.74           C  
+ATOM   1375  CG1 VAL B  80      -8.972   4.552 -29.297  1.00 49.27           C  
+ATOM   1376  CG2 VAL B  80      -9.558   6.852 -30.070  1.00 63.92           C  
+ATOM   1377  N   THR B  81      -8.179   5.456 -25.968  1.00 69.93           N  
+ATOM   1378  CA  THR B  81      -7.638   4.526 -24.979  1.00 59.01           C  
+ATOM   1379  C   THR B  81      -8.559   4.404 -23.767  1.00 60.88           C  
+ATOM   1380  O   THR B  81      -8.809   3.302 -23.279  1.00 74.62           O  
+ATOM   1381  CB  THR B  81      -6.235   4.954 -24.509  1.00 61.43           C  
+ATOM   1382  OG1 THR B  81      -5.392   5.174 -25.647  1.00 65.25           O  
+ATOM   1383  CG2 THR B  81      -5.620   3.881 -23.630  1.00 57.05           C  
+ATOM   1384  N   THR B  82      -9.051   5.540 -23.285  1.00 61.20           N  
+ATOM   1385  CA  THR B  82      -9.962   5.580 -22.143  1.00 71.40           C  
+ATOM   1386  C   THR B  82     -11.203   4.718 -22.406  1.00 74.31           C  
+ATOM   1387  O   THR B  82     -11.628   3.941 -21.551  1.00 90.81           O  
+ATOM   1388  CB  THR B  82     -10.393   7.026 -21.827  1.00 66.83           C  
+ATOM   1389  OG1 THR B  82      -9.271   7.767 -21.332  1.00 68.12           O  
+ATOM   1390  CG2 THR B  82     -11.510   7.046 -20.796  1.00 83.97           C  
+ATOM   1391  N   ALA B  83     -11.764   4.866 -23.602  1.00 71.89           N  
+ATOM   1392  CA  ALA B  83     -12.945   4.124 -24.051  1.00 62.94           C  
+ATOM   1393  C   ALA B  83     -12.727   2.608 -24.055  1.00 77.55           C  
+ATOM   1394  O   ALA B  83     -13.600   1.838 -23.655  1.00101.23           O  
+ATOM   1395  CB  ALA B  83     -13.360   4.597 -25.435  1.00 65.76           C  
+ATOM   1396  N   CYS B  84     -11.548   2.200 -24.507  1.00 71.24           N  
+ATOM   1397  CA  CYS B  84     -11.131   0.798 -24.560  1.00 78.42           C  
+ATOM   1398  C   CYS B  84     -10.980   0.179 -23.171  1.00 87.72           C  
+ATOM   1399  O   CYS B  84     -11.199  -1.018 -22.991  1.00 87.71           O  
+ATOM   1400  CB  CYS B  84      -9.823   0.664 -25.340  1.00 78.62           C  
+ATOM   1401  SG  CYS B  84      -9.927   1.246 -27.048  1.00 88.19           S  
+ATOM   1402  N   HIS B  85     -10.603   1.000 -22.199  1.00 80.25           N  
+ATOM   1403  CA  HIS B  85     -10.433   0.553 -20.821  1.00 94.29           C  
+ATOM   1404  C   HIS B  85     -11.763   0.119 -20.209  1.00107.86           C  
+ATOM   1405  O   HIS B  85     -11.846  -0.952 -19.606  1.00117.33           O  
+ATOM   1406  CB  HIS B  85      -9.811   1.663 -19.973  1.00 83.24           C  
+ATOM   1407  CG  HIS B  85      -9.646   1.298 -18.531  1.00 90.61           C  
+ATOM   1408  ND1 HIS B  85     -10.513   1.732 -17.551  1.00105.02           N  
+ATOM   1409  CD2 HIS B  85      -8.718   0.539 -17.901  1.00 95.47           C  
+ATOM   1410  CE1 HIS B  85     -10.127   1.256 -16.381  1.00111.46           C  
+ATOM   1411  NE2 HIS B  85      -9.039   0.530 -16.566  1.00114.89           N  
+ATOM   1412  N   GLU B  86     -12.793   0.946 -20.350  1.00 94.02           N  
+ATOM   1413  CA  GLU B  86     -14.102   0.650 -19.770  1.00116.10           C  
+ATOM   1414  C   GLU B  86     -14.687  -0.674 -20.269  1.00129.09           C  
+ATOM   1415  O   GLU B  86     -15.361  -1.378 -19.517  1.00135.26           O  
+ATOM   1416  CB  GLU B  86     -15.089   1.779 -20.067  1.00111.25           C  
+ATOM   1417  CG  GLU B  86     -14.814   3.067 -19.320  1.00114.07           C  
+ATOM   1418  CD  GLU B  86     -16.089   3.804 -18.963  1.00121.15           C  
+ATOM   1419  OE1 GLU B  86     -17.112   3.132 -18.711  1.00126.45           O  
+ATOM   1420  OE2 GLU B  86     -16.070   5.052 -18.938  1.00111.58           O1-
+ATOM   1421  N   PHE B  87     -14.431  -1.017 -21.528  1.00122.48           N  
+ATOM   1422  CA  PHE B  87     -14.910  -2.289 -22.069  1.00121.73           C  
+ATOM   1423  C   PHE B  87     -13.864  -3.393 -21.919  1.00120.58           C  
+ATOM   1424  O   PHE B  87     -13.782  -4.299 -22.749  1.00105.04           O  
+ATOM   1425  CB  PHE B  87     -15.287  -2.153 -23.550  1.00121.14           C  
+ATOM   1426  CG  PHE B  87     -16.547  -1.363 -23.804  1.00130.30           C  
+ATOM   1427  CD1 PHE B  87     -17.053  -0.487 -22.856  1.00123.41           C  
+ATOM   1428  CD2 PHE B  87     -17.230  -1.508 -25.001  1.00131.13           C  
+ATOM   1429  CE1 PHE B  87     -18.207   0.234 -23.101  1.00126.28           C  
+ATOM   1430  CE2 PHE B  87     -18.386  -0.793 -25.251  1.00132.03           C  
+ATOM   1431  CZ  PHE B  87     -18.875   0.079 -24.300  1.00133.74           C  
+ATOM   1432  N   PHE B  88     -13.070  -3.314 -20.855  1.00128.95           N  
+ATOM   1433  CA  PHE B  88     -12.068  -4.334 -20.567  1.00130.29           C  
+ATOM   1434  C   PHE B  88     -11.919  -4.552 -19.064  1.00120.01           C  
+ATOM   1435  O   PHE B  88     -10.895  -4.207 -18.475  1.00107.23           O  
+ATOM   1436  CB  PHE B  88     -10.719  -3.951 -21.180  1.00116.61           C  
+TER    1437      PHE B  88                                                      
+ATOM   1438  N   ALA C 697     -15.057  -4.728 -29.916  1.00 91.34           N  
+ATOM   1439  CA  ALA C 697     -15.776  -4.151 -31.044  1.00 99.08           C  
+ATOM   1440  C   ALA C 697     -17.203  -3.763 -30.658  1.00107.95           C  
+ATOM   1441  O   ALA C 697     -17.939  -4.581 -30.107  1.00120.09           O  
+ATOM   1442  CB  ALA C 697     -15.795  -5.125 -32.214  1.00 83.43           C  
+ATOM   1443  N   MET C 698     -17.598  -2.521 -30.935  1.00100.49           N  
+ATOM   1444  CA  MET C 698     -16.732  -1.509 -31.536  1.00105.86           C  
+ATOM   1445  C   MET C 698     -17.158  -0.130 -31.041  1.00111.11           C  
+ATOM   1446  O   MET C 698     -18.234   0.019 -30.462  1.00110.74           O  
+ATOM   1447  CB  MET C 698     -16.792  -1.569 -33.067  1.00102.87           C  
+ATOM   1448  CG  MET C 698     -15.544  -1.050 -33.764  1.00 72.20           C  
+ATOM   1449  SD  MET C 698     -15.497  -1.493 -35.512  1.00100.41           S  
+ATOM   1450  CE  MET C 698     -15.445  -3.282 -35.409  1.00 77.79           C  
+ATOM   1451  N   ALA C 699     -16.319   0.876 -31.265  1.00 92.51           N  
+ATOM   1452  CA  ALA C 699     -16.649   2.238 -30.860  1.00 84.49           C  
+ATOM   1453  C   ALA C 699     -17.118   3.063 -32.050  1.00 91.13           C  
+ATOM   1454  O   ALA C 699     -17.238   2.552 -33.161  1.00101.73           O  
+ATOM   1455  CB  ALA C 699     -15.456   2.900 -30.195  1.00 75.84           C  
+ATOM   1456  N   ALA C 700     -17.382   4.342 -31.804  1.00 99.39           N  
+ATOM   1457  CA  ALA C 700     -17.819   5.270 -32.841  1.00106.92           C  
+ATOM   1458  C   ALA C 700     -17.573   6.695 -32.371  1.00115.99           C  
+ATOM   1459  O   ALA C 700     -17.023   6.906 -31.288  1.00112.36           O  
+ATOM   1460  CB  ALA C 700     -19.289   5.054 -33.173  1.00 91.18           C  
+ATOM   1461  N   THR C 701     -17.979   7.677 -33.173  1.00113.28           N  
+ATOM   1462  CA  THR C 701     -17.909   9.074 -32.745  1.00111.09           C  
+ATOM   1463  C   THR C 701     -18.959   9.277 -31.658  1.00103.80           C  
+ATOM   1464  O   THR C 701     -18.908  10.239 -30.894  1.00108.64           O  
+ATOM   1465  CB  THR C 701     -18.142  10.063 -33.910  1.00115.02           C  
+ATOM   1466  OG1 THR C 701     -17.424  11.276 -33.662  1.00 86.15           O  
+ATOM   1467  CG2 THR C 701     -19.628  10.363 -34.097  1.00108.30           C  
+ATOM   1468  N   TYR C 702     -19.911   8.347 -31.615  1.00111.64           N  
+ATOM   1469  CA  TYR C 702     -20.832   8.207 -30.496  1.00104.15           C  
+ATOM   1470  C   TYR C 702     -20.085   8.214 -29.165  1.00100.58           C  
+ATOM   1471  O   TYR C 702     -20.245   9.125 -28.368  1.00 96.05           O  
+ATOM   1472  CB  TYR C 702     -21.634   6.910 -30.625  1.00118.49           C  
+ATOM   1473  CG  TYR C 702     -22.963   7.053 -31.322  1.00123.59           C  
+ATOM   1474  CD1 TYR C 702     -23.652   8.262 -31.312  1.00109.44           C  
+ATOM   1475  CD2 TYR C 702     -23.540   5.974 -31.985  1.00126.29           C  
+ATOM   1476  CE1 TYR C 702     -24.874   8.391 -31.947  1.00115.47           C  
+ATOM   1477  CE2 TYR C 702     -24.765   6.100 -32.623  1.00126.94           C  
+ATOM   1478  CZ  TYR C 702     -25.426   7.312 -32.599  1.00132.61           C  
+ATOM   1479  OH  TYR C 702     -26.645   7.454 -33.229  1.00108.83           O  
+ATOM   1480  N   SER C 703     -19.276   7.174 -28.967  1.00 97.77           N  
+ATOM   1481  CA  SER C 703     -18.496   6.968 -27.755  1.00 97.37           C  
+ATOM   1482  C   SER C 703     -17.280   7.882 -27.672  1.00 98.11           C  
+ATOM   1483  O   SER C 703     -16.780   8.182 -26.583  1.00 90.86           O  
+ATOM   1484  CB  SER C 703     -18.034   5.510 -27.660  1.00 91.95           C  
+ATOM   1485  OG  SER C 703     -19.130   4.615 -27.753  1.00 69.47           O  
+ATOM   1486  N   ALA C 704     -16.784   8.288 -28.835  1.00104.25           N  
+ATOM   1487  CA  ALA C 704     -15.628   9.172 -28.904  1.00 95.60           C  
+ATOM   1488  C   ALA C 704     -16.011  10.542 -28.367  1.00 95.70           C  
+ATOM   1489  O   ALA C 704     -15.308  11.092 -27.516  1.00 98.31           O  
+ATOM   1490  CB  ALA C 704     -15.091   9.260 -30.321  1.00 99.90           C  
+ATOM   1491  N   LEU C 705     -17.125  11.089 -28.845  1.00 90.08           N  
+ATOM   1492  CA  LEU C 705     -17.621  12.369 -28.345  1.00101.15           C  
+ATOM   1493  C   LEU C 705     -18.028  12.265 -26.882  1.00107.55           C  
+ATOM   1494  O   LEU C 705     -18.022  13.265 -26.157  1.00109.38           O  
+ATOM   1495  CB  LEU C 705     -18.815  12.855 -29.178  1.00 78.89           C  
+ATOM   1496  CG  LEU C 705     -18.541  13.575 -30.501  1.00 88.43           C  
+ATOM   1497  CD1 LEU C 705     -19.796  13.588 -31.357  1.00 71.62           C  
+ATOM   1498  CD2 LEU C 705     -18.055  14.994 -30.246  1.00 98.57           C  
+ATOM   1499  N   ASN C 706     -18.376  11.051 -26.459  1.00101.52           N  
+ATOM   1500  CA  ASN C 706     -18.816  10.789 -25.090  1.00103.86           C  
+ATOM   1501  C   ASN C 706     -17.713  10.945 -24.048  1.00 96.78           C  
+ATOM   1502  O   ASN C 706     -17.994  11.047 -22.857  1.00 92.04           O  
+ATOM   1503  CB  ASN C 706     -19.409   9.376 -24.996  1.00102.81           C  
+ATOM   1504  CG  ASN C 706     -20.874   9.375 -24.598  1.00101.34           C  
+ATOM   1505  OD1 ASN C 706     -21.756   9.495 -25.447  1.00105.86           O  
+ATOM   1506  ND2 ASN C 706     -21.139   9.243 -23.303  1.00 92.72           N  
+ATOM   1507  N   SER C 707     -16.462  10.960 -24.495  1.00110.00           N  
+ATOM   1508  CA  SER C 707     -15.337  11.114 -23.578  1.00110.87           C  
+ATOM   1509  C   SER C 707     -14.438  12.282 -23.982  1.00111.84           C  
+ATOM   1510  O   SER C 707     -13.219  12.231 -23.815  1.00 98.42           O  
+ATOM   1511  CB  SER C 707     -14.521   9.819 -23.500  1.00 88.31           C  
+ATOM   1512  OG  SER C 707     -13.999   9.460 -24.767  1.00 92.72           O  
+ATOM   1513  N   SER C 708     -15.049  13.333 -24.519  1.00125.79           N  
+ATOM   1514  CA  SER C 708     -14.330  14.563 -24.831  1.00132.07           C  
+ATOM   1515  C   SER C 708     -14.591  15.601 -23.745  1.00159.54           C  
+ATOM   1516  O   SER C 708     -13.752  16.460 -23.472  1.00171.41           O  
+ATOM   1517  CB  SER C 708     -14.743  15.105 -26.201  1.00137.03           C  
+ATOM   1518  OG  SER C 708     -16.128  15.401 -26.240  1.00132.23           O  
+ATOM   1519  N   LYS C 709     -15.766  15.504 -23.130  1.00161.04           N  
+ATOM   1520  CA  LYS C 709     -16.178  16.396 -22.045  1.00168.64           C  
+ATOM   1521  C   LYS C 709     -15.873  15.871 -20.632  1.00170.58           C  
+ATOM   1522  O   LYS C 709     -15.505  16.665 -19.763  1.00173.16           O  
+ATOM   1523  CB  LYS C 709     -17.673  16.706 -22.165  1.00156.06           C  
+ATOM   1524  CG  LYS C 709     -18.323  17.272 -20.914  1.00136.38           C  
+ATOM   1525  CD  LYS C 709     -19.404  16.332 -20.408  1.00120.81           C  
+ATOM   1526  CE  LYS C 709     -20.241  16.977 -19.319  1.00105.57           C  
+ATOM   1527  NZ  LYS C 709     -21.376  16.102 -18.917  1.00 96.93           N1+
+ATOM   1528  N   PRO C 710     -16.034  14.548 -20.384  1.00164.51           N  
+ATOM   1529  CA  PRO C 710     -15.604  14.015 -19.083  1.00170.76           C  
+ATOM   1530  C   PRO C 710     -14.189  14.433 -18.692  1.00176.52           C  
+ATOM   1531  O   PRO C 710     -13.869  14.492 -17.505  1.00177.97           O  
+ATOM   1532  CB  PRO C 710     -15.684  12.504 -19.289  1.00154.01           C  
+ATOM   1533  CG  PRO C 710     -16.822  12.342 -20.213  1.00148.99           C  
+ATOM   1534  CD  PRO C 710     -16.773  13.525 -21.151  1.00147.11           C  
+ATOM   1535  N   THR C 711     -13.357  14.716 -19.688  1.00175.85           N  
+ATOM   1536  CA  THR C 711     -12.055  15.317 -19.446  1.00172.47           C  
+ATOM   1537  C   THR C 711     -11.536  16.071 -20.656  1.00170.72           C  
+ATOM   1538  O   THR C 711     -11.369  15.493 -21.730  1.00166.30           O  
+ATOM   1539  CB  THR C 711     -10.999  14.268 -19.063  1.00161.62           C  
+ATOM   1540  OG1 THR C 711     -11.573  12.960 -19.144  1.00151.32           O  
+ATOM   1541  CG2 THR C 711     -10.476  14.520 -17.653  1.00156.11           C  
+ATOM   1542  N   PRO C 712     -11.278  17.373 -20.485  1.00166.51           N  
+ATOM   1543  CA  PRO C 712     -10.334  18.024 -21.392  1.00158.27           C  
+ATOM   1544  C   PRO C 712      -8.931  17.566 -21.010  1.00156.87           C  
+ATOM   1545  O   PRO C 712      -8.743  16.393 -20.685  1.00156.16           O  
+ATOM   1546  CB  PRO C 712     -10.547  19.514 -21.123  1.00146.40           C  
+ATOM   1547  CG  PRO C 712     -11.057  19.567 -19.721  1.00153.00           C  
+ATOM   1548  CD  PRO C 712     -11.880  18.321 -19.531  1.00155.81           C  
+ATOM   1549  N   GLN C 713      -7.955  18.462 -21.028  1.00144.44           N  
+ATOM   1550  CA  GLN C 713      -6.627  18.086 -20.562  1.00132.62           C  
+ATOM   1551  C   GLN C 713      -5.969  19.210 -19.778  1.00135.28           C  
+ATOM   1552  O   GLN C 713      -5.845  20.331 -20.269  1.00133.63           O  
+ATOM   1553  CB  GLN C 713      -5.729  17.678 -21.739  1.00129.03           C  
+ATOM   1554  CG  GLN C 713      -6.218  16.460 -22.515  1.00129.19           C  
+ATOM   1555  CD  GLN C 713      -5.101  15.513 -22.901  1.00104.67           C  
+ATOM   1556  OE1 GLN C 713      -5.065  14.365 -22.457  1.00 87.91           O  
+ATOM   1557  NE2 GLN C 713      -4.185  15.984 -23.740  1.00104.72           N  
+ATOM   1558  N   LEU C 714      -5.553  18.906 -18.552  1.00142.09           N  
+ATOM   1559  CA  LEU C 714      -4.660  19.796 -17.824  1.00139.68           C  
+ATOM   1560  C   LEU C 714      -3.264  19.613 -18.406  1.00140.65           C  
+ATOM   1561  O   LEU C 714      -2.352  19.138 -17.728  1.00118.71           O  
+ATOM   1562  CB  LEU C 714      -4.664  19.501 -16.322  1.00124.26           C  
+ATOM   1563  CG  LEU C 714      -5.989  19.509 -15.556  1.00131.60           C  
+ATOM   1564  CD1 LEU C 714      -5.719  19.633 -14.063  1.00134.39           C  
+ATOM   1565  CD2 LEU C 714      -6.910  20.621 -16.036  1.00137.69           C  
+ATOM   1566  N   LYS C 715      -3.118  19.986 -19.675  1.00136.14           N  
+ATOM   1567  CA  LYS C 715      -1.918  19.705 -20.452  1.00117.29           C  
+ATOM   1568  C   LYS C 715      -0.658  20.267 -19.805  1.00104.00           C  
+ATOM   1569  O   LYS C 715       0.138  19.520 -19.236  1.00 97.03           O  
+ATOM   1570  CB  LYS C 715      -2.068  20.264 -21.868  1.00105.76           C  
+ATOM   1571  CG  LYS C 715      -2.393  21.746 -21.912  1.00 88.44           C  
+ATOM   1572  CD  LYS C 715      -1.524  22.457 -22.931  1.00 88.39           C  
+ATOM   1573  CE  LYS C 715      -0.049  22.251 -22.621  1.00 87.66           C  
+ATOM   1574  NZ  LYS C 715       0.832  22.940 -23.601  1.00 84.68           N1+
+TER    1575      LYS C 715                                                      
+HETATM 1576 CA    CA A 101      -4.007   0.711  -6.007  1.00 98.17          CA  
+HETATM 1577 CA    CA A 102      -7.917  11.528  -9.082  1.00160.26          CA  
+HETATM 1578 CA    CA B 101       0.798  16.007 -43.360  1.00 44.51          CA  
+HETATM 1579 CA    CA B 102      -4.300  21.669 -35.403  1.00 72.45          CA  
+CONECT  171 1576                                                                
+CONECT  192 1576                                                                
+CONECT  201 1576                                                                
+CONECT  224 1576                                                                
+CONECT  257 1576                                                                
+CONECT  258 1576                                                                
+CONECT  487 1577                                                                
+CONECT  503 1577                                                                
+CONECT  515 1577                                                                
+CONECT  524 1577                                                                
+CONECT  571 1577                                                                
+CONECT  572 1577                                                                
+CONECT  877 1578                                                                
+CONECT  898 1578                                                                
+CONECT  911 1578                                                                
+CONECT  938 1578                                                                
+CONECT  983 1578                                                                
+CONECT  984 1578                                                                
+CONECT 1229 1579                                                                
+CONECT 1245 1579                                                                
+CONECT 1246 1579                                                                
+CONECT 1257 1579                                                                
+CONECT 1258 1579                                                                
+CONECT 1266 1579                                                                
+CONECT 1313 1579                                                                
+CONECT 1314 1579                                                                
+CONECT 1576  171  192  201  224                                                 
+CONECT 1576  257  258                                                           
+CONECT 1577  487  503  515  524                                                 
+CONECT 1577  571  572                                                           
+CONECT 1578  877  898  911  938                                                 
+CONECT 1578  983  984                                                           
+CONECT 1579 1229 1245 1246 1257                                                 
+CONECT 1579 1258 1266 1313 1314                                                 
+MASTER      337    0    4    9    0    0    8    6 1576    3   34   20          
+END                                                                             

--- a/tests/files/5csn/pocket-id.yml
+++ b/tests/files/5csn/pocket-id.yml
@@ -1,0 +1,8 @@
+pocket_detection_resolution: 4.0
+pocket_measuring_resolution: 1.0
+clashing_cutoff: 3.0
+n_neighbors: 4
+n_spheres: 5
+sphere_padding: 5.0
+use_ray: false
+n_cores: 4

--- a/tests/test_pocketid.py
+++ b/tests/test_pocketid.py
@@ -46,3 +46,24 @@ def test_pocket_detect_rel1(path_rel1_config, path_rel1_output):
     num_output_files = len(glob.glob(path_rel1_output + "*.pdb")) - 1
     if num_output_files != 8:
         raise Exception("Expected 8 output files, but got " + str(num_output_files))
+
+
+def test_pocket_detect_5csn(path_5csn_config, path_5csn_output):
+    dir_output = os.path.dirname(path_5csn_output)
+    if os.path.exists(dir_output):
+        shutil.rmtree(dir_output)
+
+    config = PocketDetectConfig()
+    config.from_yaml(path_5csn_config)
+    pocket_id = PocketDetector(config)
+    pocket_id.run("./tests/files/5csn/5csn.pdb", path_5csn_output)
+
+    with open(path_5csn_output + "pocket1.pdb", "r") as f:
+        if "PointsInclusionSphere" not in f.read():
+            raise Exception(
+                "pocket1.pdb did not contain substring 'PointsInclusionSphere'"
+            )
+
+    num_output_files = len(glob.glob(path_5csn_output + "*.pdb"))
+    if num_output_files != 8:
+        raise Exception("Expected 8 output files, but got " + str(num_output_files))


### PR DESCRIPTION
Warnings would occur when we try to cluster points into `n_spheres` groups with K-means, and one of the groups is empty. In these cases, we retry K-means with a different initialization algorithm. If that still fails, we use all the points as the spheres. This only happens with tiny pockets that are unlikely to be relevant, so this should not tangibly impact results.